### PR TITLE
Fix navigation links opening new tabs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,3 @@
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
 <meta http-equiv="cleartype" content="on">
-<head>
-  <base target="_blank">
-</head>


### PR DESCRIPTION
## Summary
- remove incorrect `<base target="_blank">` from header

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae6a5d69c8331aa5d21b9c6375647