### PR TITLE
Improve fonts

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -13,8 +13,8 @@ $paragraph-indent           : false; // true, false (default)
 $indent-var                 : 0.5em;
 
 /* system typefaces */
-$serif                      : Georgia, Times, serif;
-$sans-serif                 : "Trebuchet MS", Helvetica, sans-serif;
+$serif                      : 'Merriweather', serif;
+$sans-serif                 : 'Inter', Helvetica, Arial, sans-serif;
 // $sans-serif                 : Georgia, serif, sans-serif;
 
 // $sans-serif                 : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
@@ -32,7 +32,7 @@ $calisto                    : "Calisto MT", serif;
 $garamond                   : Garamond, serif;
 
 $global-font-family         : $sans-serif;
-$header-font-family         : $sans-serif;
+$header-font-family         : $serif;
 $caption-font-family        : $serif;
 
 /* type scale */


### PR DESCRIPTION
## Summary
- use Inter and Merriweather fonts sitewide

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install --path vendor/bundle` *(fails: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_685b041b91fc8331bd69427e42656302