### PR TITLE
Improve list styling and add retrieval-based chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ Some examples:
 1. If you change the source code of the website, the livereload server will automatically refresh.
 1. When you finish the modification of your homepage, `commit` your changings and `push` to your remote REPO using `git` command.
 
+## Local Q&A Chat
+
+You can experiment with a simple retrieval-augmented chat bot that answers questions using only the content of this website.
+
+1. Install the dependencies:
+
+   ```bash
+   pip install -r llm_chat/requirements.txt
+   ```
+
+2. Run the chat interface:
+
+   ```bash
+   python llm_chat/chat.py
+   ```
+
+   The script uses the `distilgpt2` model by default. Set the `LLM_MODEL` environment variable if you want to use a different Hugging Face model path.
+
 # Acknowledges
 
 - AcadHomepage incorporates Font Awesome, which is distributed under the terms of the SIL OFL 1.1 and MIT License.

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -72,7 +72,7 @@ ins {
 }
 
 ul {
-  padding-inline-start: 2em;
+  padding-inline-start: 1.2em;
   margin-block-start: 0.5em;
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -185,7 +185,7 @@ h1:before, .anchor:before {
   font-size: 0.95rem;
   line-height: 1.5;
   list-style-position: outside;
-  margin-left: 1em;
+  margin-left: 0; padding-left: 1.2em;
 }
 
 .honors-section li {

--- a/llm_chat/chat.py
+++ b/llm_chat/chat.py
@@ -1,0 +1,58 @@
+import os
+import glob
+import faiss
+from sentence_transformers import SentenceTransformer
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+def load_documents(paths):
+    docs = []
+    for path in paths:
+        with open(path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        for chunk in text.split('\n\n'):
+            chunk = chunk.strip()
+            if chunk:
+                docs.append((path, chunk))
+    return docs
+
+
+def build_index(docs, embed_model):
+    embeddings = embed_model.encode([d[1] for d in docs], show_progress_bar=True)
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(embeddings)
+    return index, embeddings
+
+
+def search(query, docs, index, embed_model, k=3):
+    q_emb = embed_model.encode([query])
+    D, I = index.search(q_emb, k)
+    return [docs[i] for i in I[0]]
+
+
+def main():
+    embed_model = SentenceTransformer('all-MiniLM-L6-v2')
+    llm_name = os.environ.get('LLM_MODEL', 'distilgpt2')
+    tokenizer = AutoTokenizer.from_pretrained(llm_name)
+    model = AutoModelForCausalLM.from_pretrained(llm_name)
+
+    paths = glob.glob('_pages/*.md') + glob.glob('*.md')
+    docs = load_documents(paths)
+    index, _ = build_index(docs, embed_model)
+
+    print('LLM chat ready. Type "quit" to exit.')
+    while True:
+        query = input('> ')
+        if query.strip().lower() == 'quit':
+            break
+        segments = search(query, docs, index, embed_model)
+        context = '\n'.join([seg[1] for seg in segments])
+        prompt = f"Answer the question using only the information below:\n{context}\nQuestion: {query}\nAnswer:"
+        inputs = tokenizer(prompt, return_tensors='pt')
+        outputs = model.generate(**inputs, max_new_tokens=150)
+        print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/llm_chat/requirements.txt
+++ b/llm_chat/requirements.txt
@@ -1,0 +1,4 @@
+transformers
+sentence-transformers
+faiss-cpu
+torch


### PR DESCRIPTION
## Summary
- tweak list indentation in base styles
- refine honors list alignment
- document a local Q&A chat bot
- add simple retrieval-augmented chat script

## Testing
- `python -m py_compile llm_chat/chat.py`
- `bash run_server.sh` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcfb57b1083319803356a28858cfe