### PR TITLE
Add chat widget and update About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ You can experiment with a simple retrieval-augmented chat bot that answers quest
    python llm_chat/chat.py
    ```
 
+To use the chat widget on the website, start the lightweight API server:
+
+```bash
+python llm_chat/server.py
+```
+
+This server exposes a `/chat` endpoint that the site widget calls to answer questions using the content of this repository.
+
    The script uses the `distilgpt2` model by default. Set the `LLM_MODEL` environment variable if you want to use a different Hugging Face model path.
 
 # Acknowledges

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="{{ '/assets/js/vendor/jquery/jquery-1.12.4.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/chat-widget.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,5 +29,13 @@ layout: compress
 
     {% include scripts.html %}
 
+    <div id="chat-widget">
+      <button id="chat-toggle">Chat</button>
+      <div id="chat-box">
+        <div id="chat-log"></div>
+        <input id="chat-input" type="text" placeholder="Ask me anything..." />
+      </div>
+    </div>
+
   </body>
 </html>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -23,25 +23,23 @@ Hi there!
 Welcome to **Bhanu Prakash Vangala**’s website!
 
 # About Me
+
+<div class="about-me">
+
 I’m currently a Ph.D. candidate in Computer Science at the University of Missouri, Columbia (Aug 2023 – Jun 2027), co-advised by [Dr. Jianlin Cheng](https://calla.rnet.missouri.edu/cheng/) and [Dr. Tanu Malik](https://engineering.missouri.edu/faculty/tanu-malik/). I earned my M.S. in Computer Science from the University of Missouri (GPA: 4.0/4.0), where I worked on deploying Large Language Models (LLMs) in distributed computing environments advised by [Dr. Grant J Scott](https://scottgs.mufaculty.umsystem.edu/). I completed my B.Tech in Computer Science and Engineering (Data Analytics) at Vellore Institute of Technology, India, where I explored multilingual NLP and large-scale social media analysis.
 
 My current **core research interests** are funded by the **Department of Defense (U.S. Army ERDC), NSF, and NASA**, highlighting their relevance to critical scientific and technological challenges.
 
-**Trustworthy and Interpretable AI**  
-Developing systems that can reason transparently, self-reflect, and correct their own outputs—improving reliability and reducing harmful or misleading responses.
-
-**Efficient and Scalable Language Models**  
-Focusing on model compression, memory optimization, and large-scale deployment of LLMs for real-time inference in resource-constrained and HPC environments.
-
-**Factuality and Evaluation in Language Models**  
-Designing evaluation benchmarks and hybrid techniques to assess consistency, factual accuracy, and context-grounded reasoning in LLMs.
-
-**AI for Scientific Discovery**  
-Applying LLMs in scientific domains such as materials science, biomedical research, and policy modeling—empowering AI to support researchers in hypothesis generation and knowledge synthesis.
+- **Trustworthy and Interpretable AI**: Developing systems that can reason transparently, self-reflect, and correct their own outputs—improving reliability and reducing harmful or misleading responses.
+- **Efficient and Scalable Language Models**: Focusing on model compression, memory optimization, and large-scale deployment of LLMs for real-time inference in resource-constrained and HPC environments.
+- **Factuality and Evaluation in Language Models**: Designing evaluation benchmarks and hybrid techniques to assess consistency, factual accuracy, and context-grounded reasoning in LLMs.
+- **AI for Scientific Discovery**: Applying LLMs in scientific domains such as materials science, biomedical research, and policy modeling—empowering AI to support researchers in hypothesis generation and knowledge synthesis.
 
 Beyond research, I enjoy mentoring students as a Teaching Assistant for full-stack web development courses, helping them connect theoretical concepts with real-world applications. I’m also passionate about guiding international students through blogging and sharing insights on pursuing higher education abroad.
 
 Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanuprakashvangala.github.io) or connect with me on [LinkedIn](https://www.linkedin.com/in/vangalabhanuprakash/)!
+
+</div>
 
 [//]: <> <span style="color:blue"> </span>
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,0 +1,57 @@
+# Custom styles for chat widget and about page
+
+.about-me {
+  text-align: justify;
+  margin: 0 1em 1em 1em;
+  line-height: 1.5;
+}
+
+.about-me ul {
+  padding-left: 1.2em;
+}
+
+#chat-widget {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  font-family: $global-font-family;
+}
+
+#chat-toggle {
+  background-color: $color-secondary;
+  color: #fff;
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: $border-radius;
+  cursor: pointer;
+}
+
+#chat-box {
+  display: none;
+  position: absolute;
+  bottom: 40px;
+  right: 0;
+  width: 300px;
+  max-height: 400px;
+  background: #fff;
+  border: 1px solid $border-color;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+#chat-box.visible {
+  display: block;
+}
+
+#chat-log {
+  padding: 0.5em;
+  max-height: 300px;
+  overflow-y: auto;
+  font-size: 0.9em;
+}
+
+#chat-input {
+  width: calc(100% - 1em);
+  margin: 0.5em;
+}
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,6 +39,7 @@
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+@import "custom";
 
 /* 1) Import Web Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Merriweather:wght@700&display=swap');

--- a/assets/js/chat-widget.js
+++ b/assets/js/chat-widget.js
@@ -1,0 +1,35 @@
+(function(){
+  var toggle = document.getElementById('chat-toggle');
+  var box = document.getElementById('chat-box');
+  var log = document.getElementById('chat-log');
+  var input = document.getElementById('chat-input');
+
+  if(!toggle) return;
+
+  toggle.addEventListener('click', function(){
+    box.classList.toggle('visible');
+  });
+
+  input.addEventListener('keypress', function(e){
+    if(e.key === 'Enter'){
+      var text = input.value.trim();
+      if(!text) return;
+      appendMsg('You', text);
+      input.value = '';
+      fetch('/chat', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({query: text})
+      }).then(r => r.json())
+        .then(d => appendMsg('Bot', d.answer))
+        .catch(() => appendMsg('Error', 'Something went wrong.'));
+    }
+  });
+
+  function appendMsg(sender, msg){
+    var p = document.createElement('p');
+    p.textContent = sender + ': ' + msg;
+    log.appendChild(p);
+    log.scrollTop = log.scrollHeight;
+  }
+})();

--- a/llm_chat/requirements.txt
+++ b/llm_chat/requirements.txt
@@ -2,3 +2,4 @@ transformers
 sentence-transformers
 faiss-cpu
 torch
+flask

--- a/llm_chat/server.py
+++ b/llm_chat/server.py
@@ -1,0 +1,62 @@
+import os
+import glob
+from flask import Flask, request, jsonify
+from sentence_transformers import SentenceTransformer
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import faiss
+
+
+def load_documents(paths):
+    docs = []
+    for path in paths:
+        with open(path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        for chunk in text.split('\n\n'):
+            chunk = chunk.strip()
+            if chunk:
+                docs.append((path, chunk))
+    return docs
+
+
+def build_index(docs, embed_model):
+    embeddings = embed_model.encode([d[1] for d in docs], show_progress_bar=True)
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(embeddings)
+    return index
+
+
+def search(query, docs, index, embed_model, k=3):
+    q_emb = embed_model.encode([query])
+    D, I = index.search(q_emb, k)
+    return [docs[i] for i in I[0]]
+
+
+app = Flask(__name__)
+
+embed_model = SentenceTransformer('all-MiniLM-L6-v2')
+llm_name = os.environ.get('LLM_MODEL', 'distilgpt2')
+tokenizer = AutoTokenizer.from_pretrained(llm_name)
+model = AutoModelForCausalLM.from_pretrained(llm_name)
+
+paths = glob.glob('_pages/*.md') + glob.glob('*.md')
+docs = load_documents(paths)
+index = build_index(docs, embed_model)
+
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json() or {}
+    query = data.get('query', '')
+    if not query:
+        return jsonify({'answer': ''})
+    segments = search(query, docs, index, embed_model)
+    context = '\n'.join([seg[1] for seg in segments])
+    prompt = f"Answer the question using only the information below:\n{context}\nQuestion: {query}\nAnswer:"
+    inputs = tokenizer(prompt, return_tensors='pt')
+    outputs = model.generate(**inputs, max_new_tokens=150)
+    answer = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return jsonify({'answer': answer})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- improve layout and styling of the About Me section
- add a floating chat widget and supporting styles
- load new chat script on every page
- add lightweight Flask server for retrieval-based chat
- document how to start the chat API

## Testing
- `python -m py_compile llm_chat/server.py`

------
https://chatgpt.com/codex/tasks/task_e_685dd35c26a88331ad2cb7be01b33e70