### PR TITLE
Add LLM publication image

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -123,7 +123,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
   <div class='paper-box-image'>
     <div>
       <div class="badge">Master's Thesis</div>
-      <img src='images/papers/publication-placeholder.png' alt="sym" width="100%">
+      <img src='images/LLM%20as%20Service%20-%20portfolio%20image.png' alt="sym" width="100%">
     </div>
   </div>
   <div class='paper-box-text'>


### PR DESCRIPTION
## Summary
- show actual LLM-as-a-Service portfolio image in the publications section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685df115cebc833188d47d6e874ef650