### PR TITLE
Fix LLM-as-Service image link

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -123,7 +123,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
   <div class='paper-box-image'>
     <div>
       <div class="badge">Master's Thesis</div>
-      <img src='images/LLM-as-Service-portfolio-image.png' alt="sym" width="100%">
+      <img src='{{ "/images/LLM-as-Service-portfolio-image.png" | relative_url }}' alt="LLM-as-Service portfolio image" width="100%">
     </div>
   </div>
   <div class='paper-box-text'>


### PR DESCRIPTION
## Summary
- fix the image reference for the LLM-as-Service publication

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dff94b8e48331b6cc14e768616129