### PR TITLE
Add Google Analytics and view counter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ repository               : "bhanuprakashvangala/bhanuprakashvangala.github.io"
 google_scholar_stats_use_cdn : true
 
 # google analytics
-google_analytics_id      :  # get google_analytics_id from https://analytics.google.com/analytics/
+google_analytics_id      : G-JFP04P2CJV
 
 # SEO Related
 google_site_verification :  # get google_site_verification from https://search.google.com/search-console/about

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,7 @@
 <script src="{{ '/assets/js/vendor/jquery/jquery-1.12.4.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/chat-widget.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/pageviews.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,5 +37,9 @@ layout: compress
       </div>
     </div>
 
+    <footer class="page__footer">
+      <p>Page views: <span id="page-views">loading...</span></p>
+    </footer>
+
   </body>
 </html>

--- a/assets/js/pageviews.js
+++ b/assets/js/pageviews.js
@@ -1,0 +1,10 @@
+(function(){
+  var el = document.getElementById('page-views');
+  if(!el) return;
+  var namespace = 'bhanuprakashvangala.github.io';
+  var key = location.pathname.replace(/\//g,'_');
+  fetch('https://api.countapi.xyz/update/' + namespace + '/' + key + '?amount=1')
+    .then(function(res){ return res.json(); })
+    .then(function(data){ el.textContent = data.value; })
+    .catch(function(err){ console.error('Count API error', err); });
+})();


### PR DESCRIPTION
## Summary
- enable GA4 using measurement id G-JFP04P2CJV
- show page view totals in the footer
- include script to fetch view counts from countapi

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686585abf9808331995c2ca873c7d90f