### PR TITLE
Fix SCSS syntax in custom styles

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,4 +1,4 @@
-# Custom styles for chat widget and about page
+// Custom styles for chat widget and about page
 
 .about-me {
   text-align: justify;


### PR DESCRIPTION
## Summary
- fix an invalid comment in `_sass/_custom.scss`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658b2f5f3c83319429a640e49902b8