### PR TITLE
Improve About and Education sections

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -21,35 +21,28 @@ redirect_from:
 
 # About Me
 
-
-Hi there! I'm **Bhanu Prakash Vangala**, a Ph.D. candidate in Computer Science at the University of Missouri.
-My work explores trustworthy AI, efficient language models and their applications to scientific discovery.
-Before starting my doctorate I completed an M.S. at Mizzou, where I focused on deploying LLMs in distributed
-computing environments. I enjoy mentoring students, writing about graduate life abroad and building tools that
-make AI systems more transparent and reliable.
-
-<div class="about-me">
-
-My current **core research interests** are funded by the **Department of Defense (U.S. Army ERDC), NSF, and NASA**, highlighting their relevance to critical scientific and technological challenges.
-
-<ul class="about-highlights">
-  <li><strong>Trustworthy and Interpretable AI</strong>: Developing systems that can reason transparently, self-reflect, and correct their own outputs—improving reliability and reducing harmful or misleading responses.</li>
-  <li><strong>Efficient and Scalable Language Models</strong>: Focusing on model compression, memory optimization, and large-scale deployment of LLMs for real-time inference in resource-constrained and HPC environments.</li>
-  <li><strong>Factuality and Evaluation in Language Models</strong>: Designing evaluation benchmarks and hybrid techniques to assess consistency, factual accuracy, and context-grounded reasoning in LLMs.</li>
-  <li><strong>AI for Scientific Discovery</strong>: Applying LLMs in scientific domains such as materials science, biomedical research, and policy modeling—empowering AI to support researchers in hypothesis generation and knowledge synthesis.</li>
-</ul>
-
-Beyond research, I enjoy mentoring students as a Teaching Assistant for full-stack web development courses, helping them connect theoretical concepts with real-world applications. I’m also passionate about guiding international students through blogging and sharing insights on pursuing higher education abroad.
-
-Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanuprakashvangala.github.io) or connect with me on [LinkedIn](https://www.linkedin.com/in/vangalabhanuprakash/)!
-
+<div class="about-box">
+  <div class="about-box-icon"><i class="fas fa-user"></i></div>
+  <div class="about-box-content">
+    <p>Hello! I'm <strong>Bhanu Prakash Vangala</strong>, currently pursuing a Ph.D. in Computer Science at <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">the University of Missouri</a>.</p>
+    <p>My research explores trustworthy AI, efficient language models and their application to scientific discovery. Before starting my doctorate, I earned an M.S. from Mizzou where I focused on deploying LLMs in distributed environments.</p>
+    <p>I enjoy mentoring students, writing about graduate life abroad and building tools that make AI systems more transparent and reliable. My work is supported by the Department of Defense, NSF and NASA.</p>
+    <ul class="about-highlights">
+      <li><strong>Trustworthy and Interpretable AI</strong>: Developing systems that can reason transparently and correct their own outputs.</li>
+      <li><strong>Efficient and Scalable Language Models</strong>: Model compression, memory optimization and large-scale deployments.</li>
+      <li><strong>Factuality and Evaluation</strong>: Benchmarks and techniques to assess consistency and accuracy of LLMs.</li>
+      <li><strong>AI for Scientific Discovery</strong>: Applying LLMs in materials science, biomedical research and policy modeling.</li>
+    </ul>
+    <p>Thanks for stopping by—feel free to explore my work on <a href="https://bhanuprakashvangala.github.io">GitHub</a> or connect with me on <a href="https://www.linkedin.com/in/vangalabhanuprakash/">LinkedIn</a>!</p>
+  </div>
 </div>
+
 
 [//]: <> <span style="color:blue"> </span>
 
 # 🔥 News
 
-- *2025.05*: 🎓 Earned my M.S. in Computer Science (GPA: 4.0/4.0) from the University of Missouri, Columbia.  
+- *2025.05*: 🎓 Earned my M.S. in Computer Science (GPA: 4.0/4.0) from the [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/), Columbia.  
 - *2025.04*: 🏆 Received the **Outstanding Master’s Student Award** from the MU Department of Computer Science.  
 - *2025.04*: 📤 Submitted a thesis proposal: *"Trustworthy AI: Building Self-correcting and Self-evolving Models for Scientific Discovery."*  
 - *2025.04*: 🎉 Presented our work on Hallucination Detection at **AAAI Spring Symposium 2025 on AI for Scientific Discovery track**  
@@ -61,7 +54,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
 - *2024.01*: Working as a TA for over 100 students in a web development course – guiding full-stack app development.  
 - *2023.12*: Led deployment of GPU-efficient LLM inference systems in the university’s Kubernetes-based HPC environment (Nautilus).  
 - *2023.08*: Began research on **faithfulness, interpretability, and robustness** in large generative language models.  
-- *2023.06*: 🎉 Admitted to the Ph.D. program in Computer Science at the University of Missouri.  
+- *2023.06*: 🎉 Admitted to the Ph.D. program in Computer Science at the [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/).  
 - *2023.05*: Graduated with a B.Tech in CSE (Data Analytics) from VIT Vellore.  
 - *2023.04*: 🏅 Honored with the **Excellence in Research** Award at VIT for multilingual NLP and social media analytics contributions.  
 - *2023.03*: Volunteered as an **AI Community Evangelist** at Adobe, contributing to community education and developer engagement.  
@@ -276,7 +269,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
 # Honors and Awards
 <ul class="honors-section">
   <li>
-    <strong>2025.05:</strong> <strong>Outstanding Master’s Student Award</strong>, College of Engineering, University of Missouri  
+    <strong>2025.05:</strong> <strong>Outstanding Master’s Student Award</strong>, College of Engineering, [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/)  
     <div class="honor-images">
       <img src="images/image%20with%20dean.jpg" alt="Outstanding Master’s Student Award with Dean">
       <img src="images/Outstanding%20Student.jpeg" alt="Outstanding Student Certificate">
@@ -289,8 +282,8 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
       <img src="images/Hackathon%20Winner%202.jpg" alt="MUIDSI Hackathon Award">
     </div>
   </li>
-  <li><strong>2025.04:</strong> Selected for <strong>Google PhD Fellowship Nomination</strong>, one of three University of Missouri nominees</li>
-  <li><strong>2023:</strong> <strong>Dean’s Research Excellence Award</strong>, Vellore Institute of Technology (VIT)</li>
+  <li><strong>2025.04:</strong> Selected for <strong>Google PhD Fellowship Nomination</strong>, one of three [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/) nominees</li>
+  <li><strong>2023:</strong> <strong>Dean’s Research Excellence Award</strong>, [Vellore Institute of Technology](https://vit.ac.in/schools/school-of-computer-science-and-engineering-for-ug-courses) (VIT)</li>
   <li><strong>2023:</strong> <strong>Best Department Thesis Award</strong>, VIT for B.Tech thesis on multilingual sentiment analysis</li>
   <li><strong>2022:</strong> <strong>Runner-Up</strong>, VIT AI Tech-Thon</li>
   <li><strong>2020:</strong> <strong>Certificate of Outstanding Achievement</strong>, Data Analyst Intern at Brandiverse</li>
@@ -304,7 +297,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
 <div class="edu-box">
   <div class="edu-box-icon"><i class="fas fa-user-graduate"></i></div>
   <div class="edu-box-content">
-    <h3><span class="badge bg-primary">Ph.D.</span> Computer Science, University of Missouri, Columbia</h3>
+    <h3><span class="badge bg-primary">Ph.D.</span> <small>Computer Science</small>, <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">University of Missouri</a>, Columbia</h3>
     <p class="text-secondary">2023.08 – 2027.06 (expected)</p>
     <ul>
       <li>Co-advised by Dr. Jianlin Cheng and Dr. Tanu Malik</li>
@@ -318,7 +311,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
 <div class="edu-box">
   <div class="edu-box-icon"><i class="fas fa-user-graduate"></i></div>
   <div class="edu-box-content">
-    <h3><span class="badge bg-secondary">M.S.</span> Computer Science, University of Missouri, Columbia</h3>
+    <h3><span class="badge bg-secondary">M.S.</span> <small>Computer Science</small>, <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">University of Missouri</a>, Columbia</h3>
     <p class="text-secondary">2023.08 – 2025.05</p>
     <ul>
       <li><strong>Thesis:</strong> <em>Deploying LLM-as-a-Service in Kubernetes HPC Clusters</em></li>
@@ -333,7 +326,7 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
 <div class="edu-box">
   <div class="edu-box-icon"><i class="fas fa-user-graduate"></i></div>
   <div class="edu-box-content">
-    <h3><span class="badge bg-accent">B.Tech</span> Computer Science and Engineering (Data Analytics), Vellore Institute of Technology, India</h3>
+    <h3><span class="badge bg-accent">Bachelor of Technology</span> <small>Computer Science and Engineering with Specialization in Data Analytics</small>, <a href="https://vit.ac.in/schools/school-of-computer-science-and-engineering-for-ug-courses" target="_blank">Vellore Institute of Technology, India</a></h3>
     <p class="text-secondary">2019.05 – 2023.05</p>
     <ul>
       <li>Excellence in Research and Best Department Thesis</li>
@@ -378,12 +371,12 @@ Thanks for stopping by—feel free to explore my work on [GitHub](https://bhanup
   Conducted research in Information Extraction, Web Mining, and Data Management for intelligent interfaces.  
   *Mentor*: [Nanda Kishore](https://research.adobe.com/person/nandakishore-kambhatla/)  
 
-- *Aug 2023 – Present*, **University of Missouri – Data Intensive Computing Lab**, Research & Teaching Assistant  
+- *Aug 2023 – Present*, **[University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/) – Data Intensive Computing Lab**, Research & Teaching Assistant  
   - Developed a hallucination detection framework for scientific LLMs with a 30% factual-improvement metric.  
   - Led deployment of LLM-as-a-Service using Kubernetes & Helm in HPC clusters (NSF-funded).  
   - TA for Web Development, supporting 115+ MERN-stack students.  
 
-- *Aug 2023 – Jan 2024*, **University of Missouri – PAAL Lab**, Research Assistant  
+- *Aug 2023 – Jan 2024*, **[University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/) – PAAL Lab**, Research Assistant  
   - Led a USDA-funded AI project on UAV-based crop monitoring.  
   - Designed real-time geospatial analysis workflows using QGIS.  
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -91,3 +91,41 @@
   margin: 0.5em;
 }
 
+
+.about-box {
+  display: flex;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-left: 5px solid $color-primary;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.about-box-icon {
+  flex: 0 0 50px;
+  max-width: 50px;
+  font-size: 1.8rem;
+  color: $color-primary;
+  margin-right: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.about-box-content {
+  flex: 1;
+  text-align: justify;
+}
+
+.edu-box .badge {
+  font-size: 1rem;
+  padding: 0.25em 0.7em;
+}
+
+.edu-box h3 small {
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- revamp the About Me section with a new `about-box` layout and updated text
- link University of Missouri and VIT references to their respective sites
- adjust Education entries with larger degree badges and smaller majors
- add styles for `about-box` and education badges

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*

------
https://chatgpt.com/codex/tasks/task_e_686592f10d2483318abba6b0f79736e1