### PR TITLE
Improve About page design with restored focus tabs

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -119,6 +119,11 @@
 .about-box-content {
   flex: 1;
   text-align: justify;
+  p {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin-bottom: 0.6rem;
+  }
 }
 
 .edu-box .badge {
@@ -130,28 +135,33 @@
   font-size: 1rem;
 }
 
+
 /* Vertical tabs for Areas of Focus */
 .focus-tabs {
   display: flex;
   flex-wrap: wrap;
   margin-top: 1em;
+  background: $color-bg;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 .focus-tabs .tab-labels {
   list-style: none;
   margin: 0;
-  padding: 0;
-  flex: 0 0 140px;
-  max-width: 140px;
-  margin-right: 0.5rem;
+  padding: 1rem;
+  flex: 0 0 180px;
+  max-width: 180px;
   border-right: 1px solid #e2e8f0;
 }
 
 .focus-tabs .tab-labels li {
   cursor: pointer;
-  padding: 0.35em 0.6em;
-  margin-bottom: 0.3em;
-  background: #fafafa;
+  font-weight: 500;
+  padding: 0.5em;
+  margin-bottom: 0.25em;
+  background: #fff;
   border-radius: 0.25rem;
   border-left: 3px solid transparent;
   transition: background 0.2s ease, border-color 0.2s ease;
@@ -164,14 +174,11 @@
 .focus-tabs .tab-labels li.active {
   background: #e6f0ff;
   border-color: $color-accent;
-  font-weight: bold;
 }
 
 .focus-tabs .tab-content {
   flex: 1;
-  padding: 0.6em 1em;
-  background: #fff;
-  border-radius: 0.25rem;
+  padding: 1rem;
 }
 
 .focus-tabs .tab-pane {


### PR DESCRIPTION
## Summary
- restore vertical Focus Tabs layout on About page
- add focus-tabs script back and include in scripts
- enhance fonts and layout for better readability

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865aedbe0ec8331a2c37f3918854456