### PR TITLE
Improve research area tabs and about page design

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -55,18 +55,30 @@ redirect_from:
 </div>
 
 <script>
-$(function(){
+document.addEventListener('DOMContentLoaded', function(){
   function activate(tabId){
-    $('.focus-tabs .tab-labels li').removeClass('active');
-    $('.focus-tabs .tab-labels li[data-tab="'+tabId+'"]').addClass('active');
-    $('.focus-tabs .tab-pane').removeClass('active');
-    $('#'+tabId).addClass('active');
+    document.querySelectorAll('.focus-tabs .tab-labels li').forEach(function(el){
+      el.classList.remove('active');
+    });
+    document.querySelectorAll('.focus-tabs .tab-labels li[data-tab="'+tabId+'"]').forEach(function(el){
+      el.classList.add('active');
+    });
+    document.querySelectorAll('.focus-tabs .tab-pane').forEach(function(el){
+      el.classList.remove('active');
+    });
+    var pane = document.getElementById(tabId);
+    if(pane){
+      pane.classList.add('active');
+    }
   }
-  $('.focus-tabs .tab-labels li').click(function(){
-    activate($(this).data('tab'));
+  document.querySelectorAll('.focus-tabs .tab-labels li').forEach(function(el){
+    el.addEventListener('click', function(){
+      activate(el.getAttribute('data-tab'));
+    });
   });
-  if($('.focus-tabs .tab-labels li').length){
-    activate($('.focus-tabs .tab-labels li').first().data('tab'));
+  var first = document.querySelector('.focus-tabs .tab-labels li');
+  if(first){
+    activate(first.getAttribute('data-tab'));
   }
 });
 </script>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -94,11 +94,11 @@
 
 .about-box {
   display: flex;
-  background: $color-bg;
+  background: linear-gradient(135deg, lighten($color-secondary, 45%), $color-bg);
   border: 1px solid #e2e8f0;
   border-left: 5px solid $color-secondary;
   border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.08);
   padding: 1rem 1.5rem;
   margin-bottom: 1.5rem;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- rework research-area tabs using vanilla JS so clicks work without jQuery
- add gradient background and stronger box shadow for `about-box`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b88251708331b4fd05644076be30