### PR TITLE
Refine About page and chat toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@ layout: compress
     {% include scripts.html %}
 
     <div id="chat-widget">
-      <button id="chat-toggle">Chat</button>
+      <button id="chat-toggle"><i class="fas fa-cat" aria-hidden="true"></i></button>
       <div id="chat-box">
         <div id="chat-log"></div>
         <input id="chat-input" type="text" placeholder="Ask me anything..." />

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -22,7 +22,6 @@ redirect_from:
 # About Me
 
 <div class="about-box">
-  <div class="about-box-icon"><i class="fas fa-user"></i></div>
   <div class="about-box-content">
     <p>Hello! I’m <strong>Bhanu Prakash Vangala</strong>, a Ph.D. researcher in Computer Science at <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">the University of Missouri</a>.</p>
     <p>My research focuses on advancing trustworthy and reliable AI, with an emphasis on large language models (LLMs), scalable systems, and scientific discovery. I began my graduate journey at Mizzou, completing my M.S. in Computer Science here while designing robust frameworks for deploying LLMs on distributed and high-performance computing environments — work that naturally evolved into my doctoral research.</p>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -94,7 +94,7 @@
 
 .about-box {
   display: flex;
-  background: linear-gradient(135deg, lighten($color-secondary, 45%), $color-bg);
+  background: #fff;
   border: 1px solid #e2e8f0;
   border-left: 5px solid $color-secondary;
   border-radius: 0.5rem;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -49,7 +49,7 @@ $font-serif:    'Merriweather', serif !default;
 $color-primary:   #1a202c !default;
 $color-secondary: #2b6cb0 !default;
 $color-accent:    #d69e2e !default;
-$color-bg:        #f7fafc !default;
+$color-bg:        #ffffff !default;
 $color-text:      #2d3748 !default;
 
 @import "custom";


### PR DESCRIPTION
## Summary
- simplify About Me box style
- remove user icon from About Me
- show cat icon on chat button
- use white site background

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb2acfb88331af14505dcace45a8