### PR TITLE
Enhance research focus and chat widget

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,13 +29,13 @@ layout: compress
 
     {% include scripts.html %}
 
-    <div id="chat-widget">
-      <button id="chat-toggle"><i class="fas fa-cat" aria-hidden="true"></i></button>
-      <div id="chat-box">
-        <div id="chat-log"></div>
-        <input id="chat-input" type="text" placeholder="Ask me anything..." />
+      <div id="chat-widget">
+        <button id="chat-toggle"><i class="fas fa-comments" aria-hidden="true"></i><span class="chat-label">Chat</span></button>
+        <div id="chat-box">
+          <div id="chat-log"></div>
+          <input id="chat-input" type="text" placeholder="Ask me anything..." />
+        </div>
       </div>
-    </div>
 
     <footer class="page__footer">
       <p>Page views: <span id="page-views">loading...</span></p>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -27,60 +27,28 @@ redirect_from:
     <p>My research focuses on advancing trustworthy and reliable AI, with an emphasis on large language models (LLMs), scalable systems, and scientific discovery. I began my graduate journey at Mizzou, completing my M.S. in Computer Science here while designing robust frameworks for deploying LLMs on distributed and high-performance computing environments — work that naturally evolved into my doctoral research.</p>
     <p>Supported by the Department of Defense, NSF, and NASA, my work addresses one of the most critical questions in AI today: How can we build systems that not only generate knowledge but also justify and verify their outputs?</p>
     <p>I am passionate about mentoring students, writing about graduate life abroad, and building tools that make AI systems more interpretable, reproducible, and aligned with human values — a vision that guides every aspect of my research.</p>
-    <div class="focus-tabs">
-      <ul class="tab-labels">
-        <li class="active" data-tab="focus1">Trustworthy and Interpretable AI</li>
-        <li data-tab="focus2">Efficient and Scalable Language Models</li>
-        <li data-tab="focus3">Factuality and Evaluation</li>
-        <li data-tab="focus4">AI for Scientific Discovery</li>
-      </ul>
-      <div class="tab-content">
-        <div id="focus1" class="tab-pane active">
-          <p>Developing AI systems that do more than generate fluent outputs — they can reason transparently, explain their decision processes, detect inconsistencies, and actively self-correct. My work focuses on designing architectures and evaluation frameworks that empower models to justify their responses, ultimately fostering greater trust and adoption of AI in critical domains like science, healthcare, and law.</p>
-        </div>
-        <div id="focus2" class="tab-pane">
-          <p>Pushing the boundaries of large-scale AI deployment through model compression, distributed training optimization, and advanced memory management. I design scalable architectures and Helm-based deployment pipelines that make state-of-the-art language models accessible to researchers and practitioners without requiring massive infrastructure investments, enabling equitable and practical use of cutting-edge AI technologies.</p>
-        </div>
-        <div id="focus3" class="tab-pane">
-          <p>Creating robust benchmarks and advanced evaluation pipelines to rigorously measure the factual consistency, reliability, and safety of language model outputs. By integrating contradiction detection graphs, retrieval-augmented checks, and semantic consistency metrics, I ensure that AI systems can be trusted in settings where accuracy is paramount and errors carry significant real-world consequences.</p>
-        </div>
-        <div id="focus4" class="tab-pane">
-          <p>Leveraging the power of LLMs and multimodal AI to accelerate research in materials science, biomedical innovation, and policy modeling. My work enables domain scientists to harness AI as a collaborative partner — not only to analyze and generate data, but to form hypotheses, validate findings, and drive scientific breakthroughs with greater efficiency and confidence.</p>
-        </div>
+    <div class="research-focuses">
+      <div class="focus-item">
+        <h4>Trustworthy and Interpretable AI</h4>
+        <p>Developing AI systems that do more than generate fluent outputs — they can reason transparently, explain their decision processes, detect inconsistencies, and actively self-correct. My work focuses on designing architectures and evaluation frameworks that empower models to justify their responses, ultimately fostering greater trust and adoption of AI in critical domains like science, healthcare, and law.</p>
+      </div>
+      <div class="focus-item">
+        <h4>Efficient and Scalable Language Models</h4>
+        <p>Pushing the boundaries of large-scale AI deployment through model compression, distributed training optimization, and advanced memory management. I design scalable architectures and Helm-based deployment pipelines that make state-of-the-art language models accessible to researchers and practitioners without requiring massive infrastructure investments, enabling equitable and practical use of cutting-edge AI technologies.</p>
+      </div>
+      <div class="focus-item">
+        <h4>Factuality and Evaluation</h4>
+        <p>Creating robust benchmarks and advanced evaluation pipelines to rigorously measure the factual consistency, reliability, and safety of language model outputs. By integrating contradiction detection graphs, retrieval-augmented checks, and semantic consistency metrics, I ensure that AI systems can be trusted in settings where accuracy is paramount and errors carry significant real-world consequences.</p>
+      </div>
+      <div class="focus-item">
+        <h4>AI for Scientific Discovery</h4>
+        <p>Leveraging the power of LLMs and multimodal AI to accelerate research in materials science, biomedical innovation, and policy modeling. My work enables domain scientists to harness AI as a collaborative partner — not only to analyze and generate data, but to form hypotheses, validate findings, and drive scientific breakthroughs with greater efficiency and confidence.</p>
       </div>
     </div>
     <p>Thanks for stopping by—feel free to explore my work on <a href="https://bhanuprakashvangala.github.io">GitHub</a> or connect with me on <a href="https://www.linkedin.com/in/vangalabhanuprakash/">LinkedIn</a>!</p>
   </div>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  function activate(tabId){
-    document.querySelectorAll('.focus-tabs .tab-labels li').forEach(function(el){
-      el.classList.remove('active');
-    });
-    document.querySelectorAll('.focus-tabs .tab-labels li[data-tab="'+tabId+'"]').forEach(function(el){
-      el.classList.add('active');
-    });
-    document.querySelectorAll('.focus-tabs .tab-pane').forEach(function(el){
-      el.classList.remove('active');
-    });
-    var pane = document.getElementById(tabId);
-    if(pane){
-      pane.classList.add('active');
-    }
-  }
-  document.querySelectorAll('.focus-tabs .tab-labels li').forEach(function(el){
-    el.addEventListener('click', function(){
-      activate(el.getAttribute('data-tab'));
-    });
-  });
-  var first = document.querySelector('.focus-tabs .tab-labels li');
-  if(first){
-    activate(first.getAttribute('data-tab'));
-  }
-});
-</script>
 
 
 [//]: <> <span style="color:blue"> </span>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -55,12 +55,18 @@
 }
 
 #chat-toggle {
+  display: flex;
+  align-items: center;
   background-color: $color-secondary;
   color: #fff;
   border: none;
   padding: 0.5em 1em;
   border-radius: $border-radius;
   cursor: pointer;
+}
+
+#chat-toggle .chat-label {
+  margin-left: 0.5em;
 }
 
 #chat-box {
@@ -70,9 +76,10 @@
   right: 0;
   width: 300px;
   max-height: 400px;
-  background: #fff;
+  background: #f9f9ff;
   border: 1px solid $border-color;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  border-radius: $border-radius;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
 }
 
 #chat-box.visible {
@@ -84,6 +91,9 @@
   max-height: 300px;
   overflow-y: auto;
   font-size: 0.9em;
+  p {
+    margin: 0.3em 0;
+  }
 }
 
 #chat-input {
@@ -198,4 +208,27 @@
 .focus-section p {
   margin-bottom: 0.5rem;
   text-align: justify;
+}
+
+/* Grid boxes for research focus */
+.research-focuses {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1em;
+}
+
+.research-focuses .focus-item {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-left: 5px solid $color-secondary;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  padding: 1rem;
+}
+
+.research-focuses .focus-item h4 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: $color-secondary;
 }


### PR DESCRIPTION
## Summary
- rework research focus section in `about.md` to use standalone boxes
- update default layout to show full chat button
- style chat widget and new research section in custom SCSS

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c61275ac8331a7a238aa2deb0dc4