### PR TITLE
Add chat suggestions widget

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,10 +30,19 @@ layout: compress
     {% include scripts.html %}
 
       <div id="chat-widget">
-        <button id="chat-toggle"><i class="fas fa-comments" aria-hidden="true"></i><span class="chat-label">Chat</span></button>
+        <button id="chat-toggle"><i class="fas fa-comments" aria-hidden="true"></i><span class="chat-label">Chat with me!</span></button>
         <div id="chat-box">
+          <div class="chat-header"><span class="chat-title">T-001</span><button id="chat-close" aria-label="Close">&times;</button></div>
+          <div id="chat-suggestions">
+            <button class="chat-suggestion">What's your biggest accomplishment?</button>
+            <button class="chat-suggestion">Key projects to see?</button>
+            <button class="chat-suggestion">Why should we hire you?</button>
+          </div>
           <div id="chat-log"></div>
-          <input id="chat-input" type="text" placeholder="Ask me anything..." />
+          <div class="chat-input-row">
+            <input id="chat-input" type="text" placeholder="Ask me anything..." />
+            <button id="chat-send">Send</button>
+          </div>
         </div>
       </div>
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -80,10 +80,47 @@
   border: 1px solid $border-color;
   border-radius: $border-radius;
   box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  display: flex;
+  flex-direction: column;
 }
 
 #chat-box.visible {
   display: block;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: $color-secondary;
+  color: #fff;
+  padding: 0.3em 0.5em;
+  border-top-left-radius: $border-radius;
+  border-top-right-radius: $border-radius;
+}
+
+#chat-close {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.2em;
+}
+
+#chat-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+  padding: 0.5em;
+  border-bottom: 1px solid $border-color;
+  button {
+    background: $color-bg;
+    border: 1px solid $border-color;
+    border-radius: 0.25em;
+    padding: 0.25em 0.5em;
+    font-size: 0.85em;
+    cursor: pointer;
+  }
 }
 
 #chat-log {
@@ -99,6 +136,21 @@
 #chat-input {
   width: calc(100% - 1em);
   margin: 0.5em;
+}
+
+.chat-input-row {
+  display: flex;
+  padding: 0.5em;
+}
+
+#chat-send {
+  margin-left: 0.5em;
+  padding: 0.2em 0.6em;
+  background: $color-secondary;
+  color: #fff;
+  border: none;
+  border-radius: $border-radius;
+  cursor: pointer;
 }
 
 

--- a/assets/js/chat-widget.js
+++ b/assets/js/chat-widget.js
@@ -1,31 +1,57 @@
+
 (function(){
   function init(){
     var toggle = document.getElementById('chat-toggle');
     var box = document.getElementById('chat-box');
     var log = document.getElementById('chat-log');
     var input = document.getElementById('chat-input');
+    var send = document.getElementById('chat-send');
+    var close = document.getElementById('chat-close');
+    var suggestionButtons = document.querySelectorAll('.chat-suggestion');
 
     if(!toggle) return;
 
     toggle.addEventListener('click', function(){
-      box.classList.toggle('visible');
+      box.classList.add('visible');
     });
+
+    if(close){
+      close.addEventListener('click', function(){
+        box.classList.remove('visible');
+      });
+    }
 
     input.addEventListener('keypress', function(e){
       if(e.key === 'Enter'){
-        var text = input.value.trim();
-        if(!text) return;
-        appendMsg('You', text);
-        input.value = '';
-        fetch('/chat', {
-          method: 'POST',
-          headers: {'Content-Type':'application/json'},
-          body: JSON.stringify({query: text})
-        }).then(r => r.json())
-          .then(d => appendMsg('Bot', d.answer))
-          .catch(() => appendMsg('Error', 'Something went wrong.'));
+        sendMessage(input.value);
       }
     });
+
+    if(send){
+      send.addEventListener('click', function(){
+        sendMessage(input.value);
+      });
+    }
+
+    suggestionButtons.forEach(function(btn){
+      btn.addEventListener('click', function(){
+        sendMessage(btn.textContent);
+      });
+    });
+
+    function sendMessage(text){
+      text = text.trim();
+      if(!text) return;
+      appendMsg('You', text);
+      input.value = '';
+      fetch('/chat', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({query: text})
+      }).then(r => r.json())
+        .then(d => appendMsg('Bot', d.answer))
+        .catch(() => appendMsg('Error', 'Something went wrong.'));
+    }
 
     function appendMsg(sender, msg){
       var p = document.createElement('p');


### PR DESCRIPTION
## Summary
- enhance chat popup markup and button text
- add quick question suggestions and send button
- support popup header with close button
- add corresponding styles
- update chat widget JS to handle suggestions and send actions

## Testing
- `python -m py_compile llm_chat/server.py llm_chat/chat.py`

------
https://chatgpt.com/codex/tasks/task_e_6865eca9cfc48331bc462412ae10b498