### PR TITLE
Improve about page and chat widget

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -35,19 +35,19 @@ redirect_from:
         <li data-tab="focus4">AI for Scientific Discovery</li>
       </ul>
       <div class="tab-content">
-        <div id="focus1" class="tab-pane active">
+        <div id="focus1" class="tab-pane active focus-area">
           <h3>Trustworthy and Interpretable AI</h3>
           <p>Developing AI systems that do more than generate fluent outputs — they can reason transparently, explain their decision processes, detect inconsistencies, and actively self-correct. My work focuses on designing architectures and evaluation frameworks that empower models to justify their responses, ultimately fostering greater trust and adoption of AI in critical domains like science, healthcare, and law.</p>
         </div>
-        <div id="focus2" class="tab-pane">
+        <div id="focus2" class="tab-pane focus-area">
           <h3>Efficient and Scalable Language Models</h3>
           <p>Pushing the boundaries of large-scale AI deployment through model compression, distributed training optimization, and advanced memory management. I design scalable architectures and Helm-based deployment pipelines that make state-of-the-art language models accessible to researchers and practitioners without requiring massive infrastructure investments, enabling equitable and practical use of cutting-edge AI technologies.</p>
         </div>
-        <div id="focus3" class="tab-pane">
+        <div id="focus3" class="tab-pane focus-area">
           <h3>Factuality and Evaluation</h3>
           <p>Creating robust benchmarks and advanced evaluation pipelines to rigorously measure the factual consistency, reliability, and safety of language model outputs. By integrating contradiction detection graphs, retrieval-augmented checks, and semantic consistency metrics, I ensure that AI systems can be trusted in settings where accuracy is paramount and errors carry significant real-world consequences.</p>
         </div>
-        <div id="focus4" class="tab-pane">
+        <div id="focus4" class="tab-pane focus-area">
           <h3>AI for Scientific Discovery</h3>
           <p>Leveraging the power of LLMs and multimodal AI to accelerate research in materials science, biomedical innovation, and policy modeling. My work enables domain scientists to harness AI as a collaborative partner — not only to analyze and generate data, but to form hypotheses, validate findings, and drive scientific breakthroughs with greater efficiency and confidence.</p>
         </div>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -251,6 +251,14 @@
   display: block;
 }
 
+/* Styling for individual focus areas */
+.focus-area {
+  background-color: #f9f9f9;
+  padding: 15px;
+  border-radius: 10px;
+  margin-bottom: 20px;
+}
+
 .focus-section h3 {
   margin-top: 0;
   color: $color-secondary;

--- a/assets/js/chat-widget.js
+++ b/assets/js/chat-widget.js
@@ -12,12 +12,12 @@
     if(!toggle) return;
 
     toggle.addEventListener('click', function(){
-      box.classList.add('visible');
+      box.style.display = 'flex';
     });
 
     if(close){
       close.addEventListener('click', function(){
-        box.classList.remove('visible');
+        box.style.display = 'none';
       });
     }
 


### PR DESCRIPTION
## Summary
- style focus area blocks in About section with padding and light background
- show/hide the chat popup with click handlers

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f181fee883318c3e05a5a0fd55bc