### PR TITLE
Enhance about page styling and connect chatbot to OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,7 @@ To use the chat widget on the website, start the lightweight API server:
 python llm_chat/server.py
 ```
 
-This server exposes a `/chat` endpoint that the site widget calls to answer questions using the content of this repository.
-
-   The script uses the `distilgpt2` model by default. Set the `LLM_MODEL` environment variable if you want to use a different Hugging Face model path.
+This server exposes an `/api/chat` endpoint that the site widget calls to answer questions using OpenAI's API and Bhanu's profile context. Set the `OPENAI_API_KEY` environment variable with your API key before running.
 
 # Acknowledges
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -35,21 +35,25 @@ redirect_from:
         <li data-tab="focus4">AI for Scientific Discovery</li>
       </ul>
       <div class="tab-content">
-        <div id="focus1" class="tab-pane active focus-area">
-          <h3>Trustworthy and Interpretable AI</h3>
+        <div id="focus1" class="tab-pane active focus-area focus-area-section">
+          <h3 class="side-heading">Trustworthy and Interpretable AI</h3>
           <p>Developing AI systems that do more than generate fluent outputs — they can reason transparently, explain their decision processes, detect inconsistencies, and actively self-correct. My work focuses on designing architectures and evaluation frameworks that empower models to justify their responses, ultimately fostering greater trust and adoption of AI in critical domains like science, healthcare, and law.</p>
+          <hr />
         </div>
-        <div id="focus2" class="tab-pane focus-area">
-          <h3>Efficient and Scalable Language Models</h3>
+        <div id="focus2" class="tab-pane focus-area focus-area-section">
+          <h3 class="side-heading">Efficient and Scalable Language Models</h3>
           <p>Pushing the boundaries of large-scale AI deployment through model compression, distributed training optimization, and advanced memory management. I design scalable architectures and Helm-based deployment pipelines that make state-of-the-art language models accessible to researchers and practitioners without requiring massive infrastructure investments, enabling equitable and practical use of cutting-edge AI technologies.</p>
+          <hr />
         </div>
-        <div id="focus3" class="tab-pane focus-area">
-          <h3>Factuality and Evaluation</h3>
+        <div id="focus3" class="tab-pane focus-area focus-area-section">
+          <h3 class="side-heading">Factuality and Evaluation</h3>
           <p>Creating robust benchmarks and advanced evaluation pipelines to rigorously measure the factual consistency, reliability, and safety of language model outputs. By integrating contradiction detection graphs, retrieval-augmented checks, and semantic consistency metrics, I ensure that AI systems can be trusted in settings where accuracy is paramount and errors carry significant real-world consequences.</p>
+          <hr />
         </div>
-        <div id="focus4" class="tab-pane focus-area">
-          <h3>AI for Scientific Discovery</h3>
+        <div id="focus4" class="tab-pane focus-area focus-area-section">
+          <h3 class="side-heading">AI for Scientific Discovery</h3>
           <p>Leveraging the power of LLMs and multimodal AI to accelerate research in materials science, biomedical innovation, and policy modeling. My work enables domain scientists to harness AI as a collaborative partner — not only to analyze and generate data, but to form hypotheses, validate findings, and drive scientific breakthroughs with greater efficiency and confidence.</p>
+          <hr />
         </div>
       </div>
     </div>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -291,3 +291,17 @@
   margin-bottom: 0.5rem;
   color: $color-secondary;
 }
+
+/* Side heading styling for About page focus areas */
+.side-heading {
+  font-weight: bold;
+}
+
+/* Wrapper styling for each focus area section */
+.focus-area-section {
+  background-color: #f9f9f9;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+}

--- a/assets/js/chat-widget.js
+++ b/assets/js/chat-widget.js
@@ -44,7 +44,7 @@
       if(!text) return;
       appendMsg('You', text);
       input.value = '';
-      fetch('/chat', {
+      fetch('/api/chat', {
         method: 'POST',
         headers: {'Content-Type':'application/json'},
         body: JSON.stringify({query: text})

--- a/llm_chat/requirements.txt
+++ b/llm_chat/requirements.txt
@@ -3,3 +3,4 @@ sentence-transformers
 faiss-cpu
 torch
 flask
+openai

--- a/llm_chat/server.py
+++ b/llm_chat/server.py
@@ -1,62 +1,47 @@
 import os
-import glob
 from flask import Flask, request, jsonify
-from sentence_transformers import SentenceTransformer
-from transformers import AutoModelForCausalLM, AutoTokenizer
-import faiss
+import openai
 
+openai.api_key = os.environ.get("OPENAI_API_KEY")
 
-def load_documents(paths):
-    docs = []
-    for path in paths:
-        with open(path, 'r', encoding='utf-8') as f:
-            text = f.read()
-        for chunk in text.split('\n\n'):
-            chunk = chunk.strip()
-            if chunk:
-                docs.append((path, chunk))
-    return docs
+PROFILE_PROMPT = """
+You are Bhanu Prakash Vangala's personal assistant chatbot.
+Here is Bhanu's profile information:
 
+- Name: Bhanu Prakash Vangala
+- Position: Ph.D. researcher in Computer Science at University of Missouri
+- Research areas: Trustworthy AI, Efficient & Scalable Language Models, Factuality, AI for Scientific Discovery
+- Passionate about mentoring, writing about grad life abroad, reproducibility, interpretability.
+- Supported by DoD, NSF, NASA.
 
-def build_index(docs, embed_model):
-    embeddings = embed_model.encode([d[1] for d in docs], show_progress_bar=True)
-    index = faiss.IndexFlatL2(embeddings.shape[1])
-    index.add(embeddings)
-    return index
-
-
-def search(query, docs, index, embed_model, k=3):
-    q_emb = embed_model.encode([query])
-    D, I = index.search(q_emb, k)
-    return [docs[i] for i in I[0]]
-
+Answer user questions as if you are Bhanu, in a friendly, professional, confident tone.
+"""
 
 app = Flask(__name__)
 
-embed_model = SentenceTransformer('all-MiniLM-L6-v2')
-llm_name = os.environ.get('LLM_MODEL', 'distilgpt2')
-tokenizer = AutoTokenizer.from_pretrained(llm_name)
-model = AutoModelForCausalLM.from_pretrained(llm_name)
-
-paths = glob.glob('_pages/*.md') + glob.glob('*.md')
-docs = load_documents(paths)
-index = build_index(docs, embed_model)
-
-
-@app.route('/chat', methods=['POST'])
+@app.route('/api/chat', methods=['POST'])
 def chat():
     data = request.get_json() or {}
     query = data.get('query', '')
     if not query:
         return jsonify({'answer': ''})
-    segments = search(query, docs, index, embed_model)
-    context = '\n'.join([seg[1] for seg in segments])
-    prompt = f"Answer the question using only the information below:\n{context}\nQuestion: {query}\nAnswer:"
-    inputs = tokenizer(prompt, return_tensors='pt')
-    outputs = model.generate(**inputs, max_new_tokens=150)
-    answer = tokenizer.decode(outputs[0], skip_special_tokens=True)
-    return jsonify({'answer': answer})
 
+    messages = [
+        {"role": "system", "content": PROFILE_PROMPT},
+        {"role": "user", "content": query}
+    ]
+
+    try:
+        completion = openai.chat.completions.create(
+            model="gpt-4o",
+            messages=messages,
+            temperature=0.7
+        )
+        answer = completion.choices[0].message.content
+    except Exception:
+        answer = "Error: Something went wrong."
+
+    return jsonify({'answer': answer})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- improve About page focus area styling
- integrate OpenAI-based chatbot backend
- send chat messages to new `/api/chat` route
- update requirements and docs

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f323b41c83318e1068b530bcf373