### PR TITLE
Switch chat backend to Mistral and add section navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ To use the chat widget on the website, start the lightweight API server:
 python llm_chat/server.py
 ```
 
-Alternatively you can run the Node.js version:
+Alternatively you can run the Node.js version (uses the Mistral model via the Hugging Face Inference API):
 
 ```bash
 npm install --prefix llm_chat
 node llm_chat/server.js
 ```
 
-This server exposes an `/api/chat` endpoint that the site widget calls to answer questions using OpenAI's API and Bhanu's profile context. Set the `OPENAI_API_KEY` environment variable with your API key before running.
+This server exposes an `/api/chat` endpoint that the site widget calls to answer questions using the Mistral-7B-Instruct-v0.2 model and Bhanu's profile context. Set the `HF_TOKEN` environment variable with your Hugging Face API token before running.
 
 # Acknowledges
 

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,6 +11,7 @@
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
+      <button id="show-all-btn" class="btn">Show All</button>
     </div>
   </div>
 </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,6 +3,7 @@
 <script src="{{ '/assets/js/focus-tabs.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/chat-widget.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/pageviews.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/navbar-sections.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -16,8 +16,7 @@ redirect_from:
 {% assign url = gsDataBaseUrl | append: "google-scholar-stats/gs_data_shieldsio.json" %}
 
 <span class='anchor' id='about-me'></span>
-
-
+<div class="page-section" id="section-about-me">
 
 # About Me
 
@@ -61,11 +60,12 @@ redirect_from:
   </div>
 </div>
 
-
+</div>
 
 [//]: <> <span style="color:blue"> </span>
 
 <span class='anchor' id='news'></span>
+<div class="page-section" id="section-news">
 # 🔥 News
 
 - *2025.05*: 🎓 Earned my M.S. in Computer Science (GPA: 4.0/4.0) from the [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/), Columbia.  
@@ -85,10 +85,13 @@ redirect_from:
 - *2023.04*: 🏅 Honored with the **Excellence in Research** Award at VIT for multilingual NLP and social media analytics contributions.  
 - *2023.03*: Volunteered as an **AI Community Evangelist** at Adobe, contributing to community education and developer engagement.  
 - *2022.11*: Served as an **Internshala Student Partner (ISP)**, leading brand campaigns and peer mentoring on campus.  
-- *2020*: Joined the **Brandiverse** team as a creative contributor, working on outreach and media strategy.  
+- *2020*: Joined the **Brandiverse** team as a creative contributor, working on outreach and media strategy.
 - *2021*: Collaborated with the **Synergy Team** at VIT, supporting student experience initiatives and university development programs.
 
+</div>
+
 <span class='anchor' id='publications'></span>
+<div class="page-section" id="section-publications">
 # Publications
 <div class='paper-box'>
   <div class='paper-box-image'>
@@ -293,7 +296,10 @@ redirect_from:
   </li>
 </ul>
 
+</div>
+
 <span class='anchor' id='honors-and-awards'></span>
+<div class="page-section" id="section-honors-and-awards">
 # Honors and Awards
 <ul class="honors-section">
   <li>
@@ -327,8 +333,10 @@ redirect_from:
 </ul>
 
 
+</div>
 
 <span class='anchor' id='educations'></span>
+<div class="page-section" id="section-educations">
 # Educations
 
 <div class="edu-box">
@@ -393,7 +401,10 @@ redirect_from:
     <p class="text-secondary">2017.03</p>
   </div>
 </div>
+</div>
+
 <span class='anchor' id='academic-service'></span>
+<div class="page-section" id="section-academic-service">
 # Academic Service
 
 - Conference Volunteer Reviewer: ICML (25, 24, 23), ACL (25, 24, 23), ICCV (25), CVPR (25), ICLR (25), AAAI (25), ICASSP (25), NeurIPS (24), EMNLP (24), ECCV (25), IJCAI (25), NAACL (25)  
@@ -401,9 +412,12 @@ redirect_from:
 
 # Teaching Experience
 
-- Fall 2025, Fall 2024, Spring 2024, Fall 2023 – TA for Web Development  
+- Fall 2025, Fall 2024, Spring 2024, Fall 2023 – TA for Web Development
+
+</div>
 
 <span class='anchor' id='internships-and-research-experience'></span>
+<div class="page-section" id="section-internships-and-research-experience">
 # Internships and Research Experience
 
 - *May 2022 – Jan 2023*, **Adobe Research**, NLP Research Intern  
@@ -426,8 +440,10 @@ redirect_from:
 - *May 2020 – Dec 2020*, **Internshala**, Internshala Student Partner (ISP)  
   Promoted internships, conducted career-building sessions, and facilitated student-industry interaction on campus.  
 
-- *2019 – 2020*, **VIT University – Synergy Team & Club Organizer**  
-  Organized AI/NLP workshops and tech events under various student bodies.  
+- *2019 – 2020*, **VIT University – Synergy Team & Club Organizer**
+  Organized AI/NLP workshops and tech events under various student bodies.
+
+</div>
 
 <!-- Statcounter code for personal website -->
 <script type="text/javascript">

--- a/assets/js/navbar-sections.js
+++ b/assets/js/navbar-sections.js
@@ -1,0 +1,48 @@
+(function(){
+  function showSection(id){
+    document.querySelectorAll('.page-section').forEach(function(sec){
+      if(sec.id === 'section-' + id){
+        sec.style.display = '';
+      } else {
+        sec.style.display = 'none';
+      }
+    });
+    var btn = document.getElementById('show-all-btn');
+    if(btn) btn.style.display = 'inline-block';
+  }
+
+  function showAll(){
+    document.querySelectorAll('.page-section').forEach(function(sec){
+      sec.style.display = '';
+    });
+    var btn = document.getElementById('show-all-btn');
+    if(btn) btn.style.display = 'none';
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('#site-nav a').forEach(function(link){
+      var href = link.getAttribute('href') || '';
+      if(href.indexOf('#') !== -1){
+        link.addEventListener('click', function(e){
+          var id = href.split('#')[1];
+          if(id){
+            e.preventDefault();
+            showSection(id);
+            var anchor = document.getElementById(id);
+            if(anchor) anchor.scrollIntoView({behavior:'smooth'});
+          }
+        });
+      }
+    });
+
+    var btn = document.getElementById('show-all-btn');
+    if(btn){
+      btn.style.display = 'none';
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        showAll();
+      });
+    }
+  });
+})();
+

--- a/llm_chat/package.json
+++ b/llm_chat/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "express": "^4.18.2",
-    "openai": "^4.32.0"
+    "node-fetch": "^2.6.7"
   }
 }

--- a/llm_chat/server.js
+++ b/llm_chat/server.js
@@ -1,32 +1,45 @@
 const express = require('express');
-const OpenAI = require('openai');
+const fetch = require('node-fetch');
 
 const app = express();
 app.use(express.json());
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const HF_API_URL = 'https://api-inference.huggingface.co/models/mistralai/Mistral-7B-Instruct-v0.2';
+const HF_TOKEN = process.env.HF_TOKEN;
 
 const systemPrompt = `
 You are Bhanu Prakash Vangala's personal assistant chatbot.
-Here is Bhanu's profile information:
-- PhD researcher in Computer Science, University of Missouri.
+Profile information:
+- PhD researcher in Computer Science at University of Missouri.
 - Research: Trustworthy AI, Scalable Language Models, Factuality & Evaluation, AI for Scientific Discovery.
-- Passionate about mentoring, reproducibility, writing about graduate life abroad. Supported by DoD, NSF, NASA.
+- Passionate about mentoring, reproducibility, and graduate life abroad writing. Supported by DoD, NSF, NASA.
 
-Answer user questions as Bhanu in friendly, professional tone.
+Answer as Bhanu in a friendly, professional, confident tone.
 `;
 
 app.post('/api/chat', async (req, res) => {
-  const userMessage = req.body.message || '';
+  const userMessage = req.body.message;
+  const prompt = `${systemPrompt}\n\nUser: ${userMessage}\nBhanu:`;
+
+  const payload = {
+    inputs: prompt,
+    parameters: { max_new_tokens: 250, temperature: 0.7 }
+  };
+
   try {
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userMessage }
-      ]
+    const hfRes = await fetch(HF_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${HF_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
     });
-    res.json({ reply: completion.choices[0].message.content });
+
+    const data = await hfRes.json();
+    const text = data[0]?.generated_text || 'Sorry, no response generated.';
+    const reply = text.split('Bhanu:')[1]?.trim() || text.trim();
+    res.json({ reply });
   } catch (err) {
     console.error(err);
     res.json({ reply: 'Sorry, something went wrong. Please try again later.' });


### PR DESCRIPTION
## Summary
- migrate Node.js chat server to use Mistral-7B-Instruct via Hugging Face
- add navbar "Show All" button and section-hiding logic
- wrap homepage sections in `.page-section` containers
- include new JS file and update scripts
- document updated server usage in README

## Testing
- `npm install --prefix llm_chat` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6865f9577dc8833195d40e2812ab63bd