### PR TITLE
Fix navigation dropdown and add focus heading

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -27,6 +27,7 @@ redirect_from:
     <p>My research focuses on advancing trustworthy and reliable AI, with an emphasis on large language models (LLMs), scalable systems, and scientific discovery. I began my graduate journey at Mizzou, completing my M.S. in Computer Science here while designing robust frameworks for deploying LLMs on distributed and high-performance computing environments — work that naturally evolved into my doctoral research.</p>
     <p>Supported by the Department of Defense, NSF, and NASA, my work addresses one of the most critical questions in AI today: How can we build systems that not only generate knowledge but also justify and verify their outputs?</p>
     <p>I am passionate about mentoring students, writing about graduate life abroad, and building tools that make AI systems more interpretable, reproducible, and aligned with human values — a vision that guides every aspect of my research.</p>
+    <h3 class="focus-heading">Areas of Focus</h3>
     <div class="focus-tabs">
       <ul class="tab-labels">
         <li class="active" data-tab="focus1">Trustworthy and Interpretable AI</li>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -272,6 +272,12 @@ html {
   text-align: justify;
 }
 
+/* Heading above the areas of focus tabs */
+.focus-heading {
+  margin-top: 1rem;
+  color: $color-secondary;
+}
+
 /* Grid boxes for research focus */
 .research-focuses {
   display: grid;

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -69,4 +69,10 @@ $btn.on('click', function() {
   $(this).toggleClass('close');
 });
 
+// hide dropdown after selecting a link
+$hlinks.on('click', 'a', function() {
+  $hlinks.addClass('hidden');
+  $btn.removeClass('close');
+});
+
 updateNav();


### PR DESCRIPTION
## Summary
- add "Areas of Focus" heading to About page
- style focus heading
- close nav dropdown when a link is clicked

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ff1c86f48331b1bc2a7cca1c4152