### PR TITLE
Add lightbox support for honor images

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -302,8 +302,12 @@ redirect_from:
     <div class="honor-content">
       <strong>Outstanding Master’s Student Award</strong>, College of Engineering, [University of Missouri](https://engineering.missouri.edu/departments/eecs/eecs-research/)
       <div class="honor-images">
-        <img src="images/image%20with%20dean.jpg" alt="Outstanding Master’s Student Award with Dean">
-        <img src="images/Outstanding%20Student.jpeg" alt="Outstanding Student Certificate">
+        <a href="images/image%20with%20dean.jpg">
+          <img src="images/image%20with%20dean.jpg" alt="Outstanding Master’s Student Award with Dean">
+        </a>
+        <a href="images/Outstanding%20Student.jpeg">
+          <img src="images/Outstanding%20Student.jpeg" alt="Outstanding Student Certificate">
+        </a>
       </div>
     </div>
   </li>
@@ -312,8 +316,12 @@ redirect_from:
     <div class="honor-content">
       <strong>Runner-Up – MUIDSI Hackathon</strong> for <em>VisionAI: AI-Powered Assistance for the Visually Impaired</em>, awarded $1,000
       <div class="honor-images">
-        <img src="images/Hackathon%20Winner.jpeg" alt="MUIDSI Hackathon Award">
-        <img src="images/Hackathon%20Winner%202.jpg" alt="MUIDSI Hackathon Award">
+        <a href="images/Hackathon%20Winner.jpeg">
+          <img src="images/Hackathon%20Winner.jpeg" alt="MUIDSI Hackathon Award">
+        </a>
+        <a href="images/Hackathon%20Winner%202.jpg">
+          <img src="images/Hackathon%20Winner%202.jpg" alt="MUIDSI Hackathon Award">
+        </a>
       </div>
     </div>
   </li>


### PR DESCRIPTION
## Summary
- make honor section images clickable so they open in the Magnific Popup lightbox

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686611e690d48331ba14944a16124e2d