### PR TITLE
Fix honor images height

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -224,8 +224,8 @@ h1:before, .anchor:before {
 }
 
 .honor-images img {
-  width: 200px;
-  height: auto;
+  height: 200px;
+  width: auto;
   border: 1px solid #ccc;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- set a fixed height for honor images so certificate and hackathon photos align

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686618352400833194b2c6f6c8284cb8