### PR TITLE
Improve site colors

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -23,7 +23,7 @@ redirect_from:
 
 <div class="about-box">
   <div class="about-box-content">
-    <p>Hello!</p>
+    <p class="text-accent">Hello!</p>
     <p>I’m <strong>Bhanu Prakash Vangala</strong>, a <strong>Ph.D. researcher in Computer Science</strong> at <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">the University of Missouri</a>.</p>
     <p>My research focuses on building AI that is <strong>trustworthy</strong>, <strong>efficient</strong>, and <strong>reliable</strong>, with an emphasis on <strong>large language models (LLMs)</strong>, <strong>high-performance computing (HPC)</strong>, and <strong>scalable, reproducible systems</strong>. I began my graduate journey at Mizzou, completing my M.S. in Computer Science under <a href="https://scottgs.mufaculty.umsystem.edu/" target="_blank">Dr. Grant Scott</a> and <a href="https://en.wikipedia.org/wiki/Jianlin_Cheng" target="_blank">Dr. Jianlin Cheng</a>. During my master’s, I worked on designing robust frameworks for deploying LLMs on distributed and HPC environments and studied hallucinations in AI for materials science — work that naturally evolved into my Ph.D. research and working under <a href="https://engineering.missouri.edu/faculty/tanu-malik/" target="_blank">Dr. Tanu Malik</a> at Radiant Lab.</p>
     <p>My work is supported by grants from the <strong>Department of Defense</strong>, <strong>NSF</strong>, and <strong>NASA</strong>. It addresses some of the most critical questions and faults in AI today: How can we build systems that not only generate knowledge but also justify/correct and verify their outputs? Can they be scalable and reproducible? Will LLMs eventually become true personal agents that understand and work alongside us?</p>
@@ -59,7 +59,7 @@ redirect_from:
         </div>
       </div>
     </div>
-    <p>Thanks for stopping by—feel free to explore my work on <a href="https://bhanuprakashvangala.github.io">GitHub</a> or connect with me on <a href="https://www.linkedin.com/in/vangalabhanuprakash/">LinkedIn</a>!</p>
+    <p class="text-secondary">Thanks for stopping by—feel free to explore my work on <a href="https://bhanuprakashvangala.github.io">GitHub</a> or connect with me on <a href="https://www.linkedin.com/in/vangalabhanuprakash/">LinkedIn</a>!</p>
   </div>
 </div>
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -7,6 +7,12 @@ html {
   text-align: justify;
   margin: 0 1em 1em 1em;
   line-height: 1.5;
+  strong {
+    color: $color-secondary;
+  }
+  a {
+    color: $color-accent;
+  }
 }
 
 .about-me ul {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -46,11 +46,11 @@
 /* 2) Color & Typography Variables */
 $font-sans:     'Inter', sans-serif !default;
 $font-serif:    'Merriweather', serif !default;
-$color-primary:   #1a202c !default;
-$color-secondary: #2b6cb0 !default;
-$color-accent:    #d69e2e !default;
+$color-primary:   #1e3a8a !default;  // deep blue for headings
+$color-secondary: #c53030 !default;  // warm red for highlights
+$color-accent:    #ff8600 !default;  // orange accent
 $color-bg:        #ffffff !default;
-$color-text:      #2d3748 !default;
+$color-text:      #333333 !default;  // slightly darker body text
 
 @import "custom";
 /* 3) Global Base Styles */


### PR DESCRIPTION
## Summary
- tweak theme color variables for a more vibrant palette
- highlight about page intro text
- style strong tags and links inside About section

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686871c5b5808331b9867311458a0d54