### PR TITLE
Improve site colors

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="{{ '/assets/js/vendor/jquery/jquery-1.12.4.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/hello-effect.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/focus-tabs.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/chat-widget.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/pageviews.js' | relative_url }}"></script>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -23,7 +23,7 @@ redirect_from:
 
 <div class="about-box">
   <div class="about-box-content">
-    <p>Hello!</p>
+    <p id="hello-text">Hello!</p>
     <p>I’m <strong>Bhanu Prakash Vangala</strong>, a <strong>Ph.D. researcher in Computer Science</strong> at <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">the University of Missouri</a>.</p>
     <p>My research focuses on building AI that is <strong>trustworthy</strong>, <strong>efficient</strong>, and <strong>reliable</strong>, with an emphasis on <strong>large language models (LLMs)</strong>, <strong>high-performance computing (HPC)</strong>, and <strong>scalable, reproducible systems</strong>. I began my graduate journey at Mizzou, completing my M.S. in Computer Science under <a href="https://scottgs.mufaculty.umsystem.edu/" target="_blank">Dr. Grant Scott</a> and <a href="https://en.wikipedia.org/wiki/Jianlin_Cheng" target="_blank">Dr. Jianlin Cheng</a>. During my master’s, I worked on designing robust frameworks for deploying LLMs on distributed and HPC environments and studied hallucinations in AI for materials science — work that naturally evolved into my Ph.D. research and working under <a href="https://engineering.missouri.edu/faculty/tanu-malik/" target="_blank">Dr. Tanu Malik</a> at Radiant Lab.</p>
     <p>My work is supported by grants from the <strong>Department of Defense</strong>, <strong>NSF</strong>, and <strong>NASA</strong>. It addresses some of the most critical questions and faults in AI today: How can we build systems that not only generate knowledge but also justify/correct and verify their outputs? Can they be scalable and reproducible? Will LLMs eventually become true personal agents that understand and work alongside us?</p>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -3,10 +3,27 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Global emphasis and links */
+body {
+  strong {
+    color: $color-secondary;
+  }
+  a {
+    color: $color-secondary;
+    &:hover { color: $color-accent; }
+  }
+}
+
 .about-me {
   text-align: justify;
   margin: 0 1em 1em 1em;
   line-height: 1.5;
+  strong {
+    color: $color-secondary;
+  }
+  a {
+    color: $color-accent;
+  }
 }
 
 .about-me ul {
@@ -313,4 +330,19 @@ html {
   border-radius: 8px;
   margin-bottom: 20px;
   border: 1px solid #ddd;
+}
+
+/* Footer coloring */
+.page__footer p {
+  color: $color-secondary;
+}
+
+@keyframes helloFloat {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+  100% { transform: translateY(0); }
+}
+
+#hello-text.float-up {
+  animation: helloFloat 1s ease-in-out;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -52,6 +52,7 @@ $color-accent:    #d69e2e !default;
 $color-bg:        #ffffff !default;
 $color-text:      #2d3748 !default;
 
+
 @import "custom";
 /* 3) Global Base Styles */
 body {

--- a/assets/js/hello-effect.js
+++ b/assets/js/hello-effect.js
@@ -1,0 +1,12 @@
+$(document).ready(function(){
+  var hello = document.getElementById('hello-text');
+  if(hello){
+    hello.style.cursor = 'pointer';
+    hello.addEventListener('click', function(){
+      hello.classList.add('float-up');
+      setTimeout(function(){
+        hello.classList.remove('float-up');
+      }, 1000);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- tweak theme color variables for a cooler palette
- add global strong and link styling
- color the site footer text
- revert to the original palette and add a floating effect when clicking on the "Hello" greeting

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686871c5b5808331b9867311458a0d54