### PR TITLE
Adjust palette to golden-orange scheme

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -47,21 +47,15 @@
 $font-sans:     'Inter', sans-serif !default;
 $font-serif:    'Merriweather', serif !default;
 
-$color-primary:   #1e40af !default;  // indigo for headings and nav
-$color-secondary: #0d9488 !default;  // teal accents
-$color-accent:    #f43f5e !default;  // rosy highlight
+$color-primary:   #b8860b !default;  // goldenrod for headings and nav
+$color-secondary: #ff8c00 !default;  // dark orange accents
+$color-accent:    #ff4500 !default;  // orange-red highlight
 $color-bg:        #ffffff !default;
-$color-text:      #334155 !default;  // slate body text
+$color-text:      #333333 !default;  // body text
 
 $primary-color: $color-primary;      // update theme variables
 $info-color:    $color-primary;
 $link-color:    $color-secondary;
-
-$color-primary:   #1e3a8a !default;  // deep blue for headings
-$color-secondary: #c53030 !default;  // warm red for highlights
-$color-accent:    #ff8600 !default;  // orange accent
-$color-bg:        #ffffff !default;
-$color-text:      #333333 !default;  // slightly darker body text
 
 
 @import "custom";


### PR DESCRIPTION
## Summary
- update main color variables
- remove duplicated palette values

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686880fcd240833183778a8a38e699c0