### PR TITLE
Adjust colors for black text and gold emphasis

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6,7 +6,7 @@ html {
 /* Global emphasis and links */
 body {
   strong {
-    color: inherit;
+    color: $color-accent;
   }
   a {
     color: $link-color;
@@ -19,7 +19,7 @@ body {
   margin: 0 1em 1em 1em;
   line-height: 1.5;
   strong {
-    color: inherit;
+    color: $color-accent;
   }
   a {
     color: $link-color;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -60,7 +60,7 @@ $body-color                 : #fff;
 $background-color           : #fff;
 $code-background-color      : #fafafa;
 $code-background-color-dark : $light-gray;
-$text-color                 : $dark-gray;
+$text-color                 : #000000;
 $border-color               : $lighter-gray;
 
 $primary-color              : #7a8288;


### PR DESCRIPTION
## Summary
- tweak text color variable for black content
- emphasize `strong` tags with gold highlight

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68688948c3b0833188323fabc4430d28