### PR TITLE
Fix link and heading colors

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -357,7 +357,7 @@ redirect_from:
 <div class="edu-box">
   <div class="edu-box-icon"><i class="fas fa-user-graduate"></i></div>
   <div class="edu-box-content">
-    <h4><span class="badge bg-secondary">M.S.</span> <small>Computer Science</small>, <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">University of Missouri</a>, Columbia</h4>
+    <h4><span class="badge bg-primary">M.S.</span> <small>Computer Science</small>, <a href="https://engineering.missouri.edu/departments/eecs/eecs-research/" target="_blank">University of Missouri</a>, Columbia</h4>
     <p class="text-secondary">2023.08 – 2025.05</p>
     <ul>
       <li><strong>Thesis:</strong> <em>Deploying LLM-as-a-Service in Kubernetes HPC Clusters</em></li>
@@ -372,7 +372,7 @@ redirect_from:
 <div class="edu-box">
   <div class="edu-box-icon"><i class="fas fa-user-graduate"></i></div>
   <div class="edu-box-content">
-    <h4><span class="badge bg-accent">Bachelor of Technology</span> <small>Computer Science and Engineering with Specialization in Data Analytics</small>, <a href="https://vit.ac.in/schools/school-of-computer-science-and-engineering-for-ug-courses" target="_blank">Vellore Institute of Technology, India</a></h4>
+    <h4><span class="badge bg-primary">Bachelor of Technology</span> <small>Computer Science and Engineering with Specialization in Data Analytics</small>, <a href="https://vit.ac.in/schools/school-of-computer-science-and-engineering-for-ug-courses" target="_blank">Vellore Institute of Technology, India</a></h4>
     <p class="text-secondary">2019.05 – 2023.05</p>
     <ul>
       <li>Excellence in Research and Best Department Thesis</li>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6,10 +6,10 @@ html {
 /* Global emphasis and links */
 body {
   strong {
-    color: $color-secondary;
+    color: inherit;
   }
   a {
-    color: $color-secondary;
+    color: $link-color;
     &:hover { color: $color-accent; }
   }
 }
@@ -19,10 +19,10 @@ body {
   margin: 0 1em 1em 1em;
   line-height: 1.5;
   strong {
-    color: $color-secondary;
+    color: inherit;
   }
   a {
-    color: $color-accent;
+    color: $link-color;
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -47,15 +47,15 @@
 $font-sans:     'Inter', sans-serif !default;
 $font-serif:    'Merriweather', serif !default;
 
-$color-primary:   #d4af37 !default;  // gold tone for headings and nav
-$color-secondary: #d4af37 !default;  // gold tone for secondary accents
+$color-primary:   #000000 !default;  // black for headings and nav
+$color-secondary: #d4af37 !default;  // secondary accent
 $color-accent:    #ffd700 !default;  // bright gold highlight
 $color-bg:        #ffffff !default;
-$color-text:      #d4af37 !default;  // body text in gold
+$color-text:      #000000 !default;  // body text in black
 
 $primary-color: $color-primary;      // update theme variables
 $info-color:    $color-primary;
-$link-color:    $color-secondary;
+$link-color:    #0066cc;
 
 
 @import "custom";
@@ -81,7 +81,7 @@ h3 { font-size: 1.75rem; }
 
 /* 4) Anchors & Link Styles */
 a {
-  color: $color-secondary;
+  color: $link-color;
   text-decoration: none;
   border-bottom: 2px solid transparent;
   transition: border-color 0.2s;


### PR DESCRIPTION
## Summary
- switch base text and heading colors to black
- color links blue across the site
- keep bold text inheriting its parent color
- use black badges for MS and B.Tech degrees

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868860758e08331b4798bb801fe2fe9