### PR TITLE
Switch site accent colors to black

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6,11 +6,7 @@ html {
 /* Global emphasis and links */
 body {
   strong {
-
-    color: inherit;
-
-    color: $color-accent;
-
+    color: #000;
   }
   a {
     color: $link-color;
@@ -23,11 +19,7 @@ body {
   margin: 0 1em 1em 1em;
   line-height: 1.5;
   strong {
-
-    color: inherit;
-
-    color: $color-accent;
-
+    color: #000;
   }
   a {
     color: $link-color;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -48,8 +48,8 @@ $font-sans:     'Inter', sans-serif !default;
 $font-serif:    'Merriweather', serif !default;
 
 $color-primary:   #000000 !default;  // black for headings and nav
-$color-secondary: #d4af37 !default;  // secondary accent
-$color-accent:    #ffd700 !default;  // bright gold highlight
+$color-secondary: #000000 !default;  // secondary accent in black
+$color-accent:    #000000 !default;  // black highlight
 $color-bg:        #ffffff !default;
 $color-text:      #000000 !default;  // body text in black
 


### PR DESCRIPTION
## Summary
- update SCSS variables to use black for secondary and accent colors
- ensure strong tags stay black

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868bd7777f08331b5b6490b196ac943