### PR TITLE
Improve publications styling and education layout

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -97,6 +97,14 @@ redirect_from:
         padding: 20px;
         margin-bottom: 1rem;
       }
+      .edu-box {
+        display: flex;
+        align-items: flex-start;
+      }
+      .edu-box-icon {
+        margin-right: 1rem;
+        font-size: 1.5rem;
+      }
       .paper-box-image .badge {
         background: #d4af37;
         color: #000;
@@ -189,7 +197,7 @@ redirect_from:
       <li>Applied to biomedical and scientific text generation tasks.</li>
     </ul>
     <div style="display: inline">
-      <a href="https://drive.google.com/file/d/1oMbe8br7-wm7NLkrOFbFGtT2vUlxdCTn/view?usp=drive_link"><strong>[paper]</strong></a>
+      <a class="pdf-link" href="https://drive.google.com/file/d/1oMbe8br7-wm7NLkrOFbFGtT2vUlxdCTn/view?usp=drive_link" title="PDF"><i class="fas fa-file-pdf"></i></a>
     </div>
     <details class='abstract'>
       <summary>Show Abstract</summary>
@@ -212,7 +220,7 @@ redirect_from:
       <li>Transformer-based architecture for multi-dimensional consistency checking of LLM outputs.</li>
     </ul>
     <div style="display: inline">
-      <a href="https://drive.google.com/file/d/1o6tqCJdhiCTAR4AEM59fV4t2VSdvS4yt/view?usp=drive_link"><strong>[paper]</strong></a>
+      <a class="pdf-link" href="https://drive.google.com/file/d/1o6tqCJdhiCTAR4AEM59fV4t2VSdvS4yt/view?usp=drive_link" title="PDF"><i class="fas fa-file-pdf"></i></a>
     </div>
     <details class='abstract'>
       <summary>Show Abstract</summary>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,0 +1,22 @@
+details.abstract {
+  margin-top: 0.5rem;
+  border: 1px solid #eee;
+  background: #fafafa;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+}
+
+details.abstract summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: $color-primary;
+}
+
+.pdf-link {
+  margin-left: 0.25rem;
+  color: $color-primary;
+}
+
+.pdf-link i {
+  font-size: 1.1rem;
+}


### PR DESCRIPTION
## Summary
- add styling for abstract details and PDF links
- use PDF icon links for papers
- adjust education layout for better alignment

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: cannot load such file -- csv)*

------
https://chatgpt.com/codex/tasks/task_e_687337d938cc8331b184d749b98849fe