### PR TITLE
Fix chat scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ Some examples:
 
 ## Interactive Chatbot
 
-The site now includes a chat widget that can answer questions using the page content. It relies on a tiny question‑answering model that is loaded directly in the browser via `@xenova/transformers`; no installation is required.
+The site now includes a chat widget that can answer questions using the page content. It relies on a tiny question‑answering model that is loaded directly in the browser via `@xenova/transformers`. The model used is [Xenova/distilbert-base-cased-distilled-squad](https://huggingface.co/distilbert-base-cased-distilled-squad) with ONNX weights so it runs entirely client side; no installation is required.
 
 Open the website and click the **Chat** button to ask a question. The model is downloaded on the first use and replies are generated from the information stored in `_pages`.
+
+If you want to experiment with the model locally you can use the `@huggingface/transformers` NPM package:
+
+```javascript
+import { pipeline } from '@huggingface/transformers';
+const answerer = await pipeline('question-answering', 'Xenova/distilbert-base-cased-distilled-squad');
+const output = await answerer('Who was Jim Henson?', 'Jim Henson was a nice puppet.');
+```
 # Acknowledges
 
 - AcadHomepage incorporates Font Awesome, which is distributed under the terms of the SIL OFL 1.1 and MIT License.

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,5 @@
 <script src="assets/js/main.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@xenova/transformers"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js"></script>
 <script src="assets/js/chat.js"></script>
 
 {% include analytics.html %}

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,1 +1,2 @@
-bundle exec jekyll liveserve
+#!/bin/bash
+bundle exec jekyll serve --livereload


### PR DESCRIPTION
## Summary
- fix server script for Jekyll
- document that the chat widget uses the DistilBERT SQuAD ONNX model and show basic usage

## Testing
- `bash run_server.sh` *(fails: bundler error)*

------
https://chatgpt.com/codex/tasks/task_e_6873587353c483319885899c0151cc2a