### PR TITLE
Fix chat widget with module import

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,8 @@
 <script src="assets/js/main.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js"></script>
+<script type="module">
+  import { pipeline } from 'https://cdn.jsdelivr.net/npm/@xenova/transformers';
+  window.transformers = { pipeline };
+</script>
 <script src="assets/js/chat.js"></script>
 
 {% include analytics.html %}


### PR DESCRIPTION
## Summary
- use a module script to import the transformers `pipeline`
- expose the pipeline on `window` for chat.js

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687408169a748331bd396838685ba254