### PR TITLE
Switch QA model and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Some examples:
 
 ## Interactive Chatbot
 
-The site now includes a chat widget that can answer questions using the page content. It relies on a tiny question‑answering model that is loaded directly in the browser via `@xenova/transformers`. The model used is [Xenova/distilbert-base-cased-distilled-squad](https://huggingface.co/distilbert-base-cased-distilled-squad) with ONNX weights so it runs entirely client side; no installation is required.
+The site now includes a chat widget that can answer questions using the page content. It relies on a tiny question‑answering model that is loaded directly in the browser via `@xenova/transformers`. The model used is [Xenova/bert-base-uncased-finetuned-squad](https://huggingface.co/Xenova/bert-base-uncased-finetuned-squad) with ONNX weights so it runs entirely client side; no installation is required.
 
 Open the website and click the **Chat** button to ask a question. The model is downloaded on the first use and replies are generated from the information stored in `_pages`.
 
@@ -75,7 +75,7 @@ If you want to experiment with the model locally you can use the `@huggingface/t
 
 ```javascript
 import { pipeline } from '@huggingface/transformers';
-const answerer = await pipeline('question-answering', 'Xenova/distilbert-base-cased-distilled-squad');
+const answerer = await pipeline('question-answering', 'Xenova/bert-base-uncased-finetuned-squad');
 const output = await answerer('Who was Jim Henson?', 'Jim Henson was a nice puppet.');
 ```
 # Acknowledges

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -1,6 +1,7 @@
 let qa;
 let qaContext = '';
-const modelId = 'Xenova/distilbert-base-cased-distilled-squad';
+// Switched to a slightly larger but still lightweight QA model
+const modelId = 'Xenova/bert-base-uncased-finetuned-squad';
 
 async function loadModel() {
   try {
@@ -84,7 +85,11 @@ async function sendMessage(text) {
     if (!qa) {
       throw new Error('Model not loaded');
     }
-    const result = await qa(text, { context: qaContext });
+    // Log the type and value of the incoming message to help debug
+    console.log('sendMessage input:', typeof text, text);
+    // Ensure the question is a string before passing to the model
+    const query = String(text);
+    const result = await qa(query, { context: qaContext });
     document.querySelector('#chat-messages').lastChild.textContent = result.answer;
   } catch (err) {
     document.querySelector('#chat-messages').lastChild.textContent = 'Error: ' + err.message;

--- a/qa_tool/qa.py
+++ b/qa_tool/qa.py
@@ -17,7 +17,8 @@ def load_context():
     return ' '.join(context)
 
 def answer_question(question, context):
-    qa = pipeline('question-answering', model='distilbert-base-cased-distilled-squad')
+    # Use an uncased BERT model fine-tuned on SQuAD for better generalization
+    qa = pipeline('question-answering', model='bert-base-uncased-finetuned-squad')
     result = qa(question=question, context=context)
     return result['answer']
 


### PR DESCRIPTION
## Summary
- upgrade QA model to `bert-base-uncased-finetuned-squad`
- log incoming message type and content before querying model
- update python helper to use the same model
- document the new model in README

## Testing
- `bundle install` *(fails: could not finish due to missing dependencies)*
- `bundle exec jekyll -v` *(fails: gems missing, suggests running `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68741e2b38888331817d9ea66e516d03