### PR TITLE
Update resume link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ author:
   facebook         :
   foursquare       :
   github           : "bhanuprakashvangala"
-  cv               : "https://drive.google.com/file/d/14WAl0Yy39fIy71NQIBQfwjxSmcAawY8q/view?usp=sharing"
+  cv               : "https://drive.google.com/file/d/1tlWZiUilKqoZiyHjKfpueTkGkwACzpqi/view?usp=sharing"
   google_plus      :
   keybase          :
   instagram        :


### PR DESCRIPTION
## Summary
- update the site configuration to point the CV link to the latest Google Drive URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1f8961fc833193f715598b5207a7