### PR TITLE
Restore missing historical news entries on About page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -37,8 +37,26 @@ I was selected as a **Google PhD Fellowship Nominee (2025)** in NLP, one of thre
 - *2026.01*: I presented **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** (Jan 26) and **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** (Jan 27) at **AAAI 2026** in Singapore
 - *2025.12*: Our paper **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** was accepted at the **RAI 2025 workshop**
 - *2025.11*: Our paper **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** was accepted at the **Deployable Artificial Intelligence (DAI2025) Workshop**
+- *2025.11*: Joining **Microsoft** as Research Data Science Intern (Summer 2026)
 - *2025.05*: Graduated with my **M.S. in Computer Science** and continued to pursue my **Ph.D. in Computer Science at Mizzou**
+- *2025.04*: Selected as a **Google PhD Fellowship Nominee (NLP)** — one of three nominees from the University of Missouri
+- *2025.04*: Presented our work on hallucination detection at the **AAAI Spring Symposium 2025 (AI for Scientific Discovery track)**
 - *2025.03*: Received the **Outstanding Master's Student Award** at the Mizzou Engineering Awards Banquet 2025
+- *2025.03*: Started development of **ReflectMemory**, focused on persistent memory control for long-context LLM reasoning
+- *2025.03*: Deployed an updated **KubeLLM** framework for multi-tenant LLM inference on GPU-based HPC clusters
+- *2025.01*: Two papers accepted at **AAAI 2025**, including **HalluMat** and **HalluFormer**
+- *2025.01*: Released benchmarking tools for **hallucination detection in scientific LLMs**
+- *2024.09*: Initiated documentation work on scalable **LLM-as-a-Service infrastructure** using Helm charts and node affinity scheduling
+- *2024.01*: Working as a TA for over 100 students in a web development course, guiding full-stack app development
+- *2023.12*: Led deployment of GPU-efficient LLM inference systems in the university’s Kubernetes-based HPC environment (Nautilus)
+- *2023.08*: Began research on **faithfulness, interpretability, and robustness** in large generative language models
+- *2023.06*: Admitted to the Ph.D. program in Computer Science at the University of Missouri
+- *2023.05*: Graduated with a B.Tech in CSE (Data Analytics) from VIT Vellore
+- *2023.04*: Honored with the **Excellence in Research** Award at VIT for multilingual NLP and social media analytics contributions
+- *2023.03*: Volunteered as an **AI Community Evangelist** at Adobe, contributing to community education and developer engagement
+- *2022.11*: Served as an **Internshala Student Partner (ISP)**, leading brand campaigns and peer mentoring on campus
+- *2021*: Collaborated with the **Synergy Team** at VIT, supporting student experience initiatives and university development programs
+- *2020*: Joined the **Brandiverse** team as a creative contributor, working on outreach and media strategy
 
 ---
 


### PR DESCRIPTION
### Motivation
- Restore previously removed historical News items so the About page shows both recent (2026/2025) and earlier milestones (HalluMat-era and prior) together.

### Description
- Rewrote the `# News` section in `/_pages/about.md` to merge recent 2026/2025 entries with historical items from 2025 back to 2020 in chronological order.
- Preserved existing anchors and surrounding structure so the `# Publications` and other sections render unchanged.
- Kept original formatting for list items and included HalluMat-era entries and related project milestones and workshop/venue mentions.

### Testing
- Reviewed the file diff for `/_pages/about.md` to confirm the News section now contains both the restored historical entries and the current items, and the surrounding anchors remain intact.
- Attempted a site build with `bundle exec jekyll build`, which failed because the environment is missing the `jekyll` executable in Bundler, so a local render could not be produced.
- Verified the updated `# News` content appears in the edited file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4d16bad88331b719a78907c82459)