### PR TITLE
Handle missing updater directory/token in profile update workflow

### DIFF
--- a/.github/workflows/update_github_myprofile.yaml
+++ b/.github/workflows/update_github_myprofile.yaml
@@ -11,6 +11,16 @@ jobs:
         sudo apt-get install python3-setuptools
     - name: Run
       run: |
+        if [ ! -d "./github_myprofile_updater" ]; then
+          echo "Skipping update: ./github_myprofile_updater not found in this repository."
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.GHRS_GITHUB_API_TOKEN }}" ]; then
+          echo "Skipping update: GHRS_GITHUB_API_TOKEN is not configured."
+          exit 0
+        fi
+
         cd ./github_myprofile_updater
         python3 update.py
         git init


### PR DESCRIPTION
### Motivation
- The `page_build` job was failing because it assumed `./github_myprofile_updater` exists and attempted to `cd` into it, and the push step could be malformed when `GHRS_GITHUB_API_TOKEN` is not set.

### Description
- Added a guard in `.github/workflows/update_github_myprofile.yaml` to exit successfully with a message when `./github_myprofile_updater` is not present.
- Added a guard to exit successfully with a message when the `GHRS_GITHUB_API_TOKEN` secret is unset.
- Preserved the original update flow (`cd`, `python3 update.py`, commit and push) when both prerequisites are present.

### Testing
- Applied the patch to `.github/workflows/update_github_myprofile.yaml` and the patch application succeeded.
- Validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file(' .github/workflows/update_github_myprofile.yaml')"` and it parsed successfully.
- Verified the changes via a repository diff check and confirmed the guard checks are present in the updated file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4e935fe08331bb0ec1de22362e26)