### PR TITLE
Remove Dr. Jianlin Cheng as advisor; add missing under-review publications and news

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,7 +12,7 @@ redirect_from:
 
 # About Me
 
-I am a Doctoral Researcher in Computer Science at the [University of Missouri](https://engineering.missouri.edu/departments/eecs/), advised by [Dr. Tanu Malik](https://engineering.missouri.edu/faculty/tanu-malik/) and [Dr. Jianlin Cheng](https://engineering.missouri.edu/faculty/jianlin-cheng/). My research focuses on **agentic AI systems**, **multi-model LLM orchestration**, and **trustworthy/reproducible machine learning systems**. I build and evaluate end-to-end platforms that reason, plan, and act autonomously across HPC and cloud environments.
+I am a Doctoral Researcher in Computer Science at the [University of Missouri](https://engineering.missouri.edu/departments/eecs/), advised by [Dr. Tanu Malik](https://engineering.missouri.edu/faculty/tanu-malik/). My research focuses on **agentic AI systems**, **multi-model LLM orchestration**, and **trustworthy/reproducible machine learning systems**. I build and evaluate end-to-end platforms that reason, plan, and act autonomously across HPC and cloud environments.
 
 I completed my M.S. in Computer Science at Missouri (GPA 4.0/4.0), where my thesis studied deploying LLMs as a service on Kubernetes-based HPC clusters. I received my B.Tech in CSE (Data Analytics) from VIT, where I worked on multilingual sentiment analysis with collaborators at IIIT Hyderabad.
 
@@ -37,6 +37,9 @@ Recent recognitions include **Google PhD Fellowship Nominee (NLP, 2025)**, **Out
 - *2026.04*: Awarded a **Chameleon Cloud Travel Award** (Top 10 proposals) for the Sixth Chameleon User Meeting
 - *2026.02*: My presentation on **"Evaluating Dependency Gaps in LLM-Generated Code"** was selected for the **Sixth Chameleon User Meeting** (April 15–16, 2026) at NCAR’s Mesa Lab in Boulder, Colorado
 - *2026.01*: I presented **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** (Jan 26) and **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** (Jan 27) at **AAAI 2026** in Singapore
+- *2026.01*: Submitted **"The Environment Specification Gap"** (extended 1,000-instance study) to **TMLR**
+- *2026.01*: Submitted **"Resource-Aware Multi-Model Serving for GPU Cloud Infrastructure"** to **IEEE CLOUD 2026**
+- *2026.01*: Submitted **"Beyond Functional Correctness: Evaluating AI-Generated Software Services"** to **ACM REP 2026**
 - *2025.12*: Our paper **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** was accepted at the **RAI 2025 workshop**
 - *2025.11*: Our paper **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** was accepted at the **Deployable Artificial Intelligence (DAI2025) Workshop**
 - *2025.11*: Received an offer from **Microsoft** for Research Data Science Internship (Summer 2026)
@@ -141,6 +144,53 @@ Recent recognitions include **Google PhD Fellowship Nominee (NLP, 2025)**, **Out
       <span class="pub-link-disabled">Poster (coming soon)</span>
       <span class="pub-link-disabled">Code (coming soon)</span>
       <span class="pub-venue">ACM SC 2025</span>
+    </div>
+  </div>
+</div>
+
+### Under Review (2026)
+
+<div class="pub-card">
+  <div class="pub-img">
+    <img src="images/LLM-as-Service-portfolio-image.png" alt="Environment Specification Gap">
+  </div>
+  <div class="pub-content">
+    <div class="pub-title">The Environment Specification Gap: An Empirical Study of Dependency Misspecification in LLM-Generated Code</div>
+    <div class="pub-authors"><a href="#">Bhanu Prakash Vangala</a>, Ashish Gehani, Tanu Malik</div>
+    <div class="pub-links">
+      <span class="pub-link-disabled">Preprint (coming soon)</span>
+      <span class="pub-link-disabled">Code (coming soon)</span>
+      <span class="pub-venue">Under Review at TMLR</span>
+    </div>
+  </div>
+</div>
+
+<div class="pub-card">
+  <div class="pub-img">
+    <img src="images/AdaptiveLLMaaS.png" alt="Resource-Aware Multi-Model Serving">
+  </div>
+  <div class="pub-content">
+    <div class="pub-title">Resource-Aware Multi-Model Serving for GPU Cloud Infrastructure</div>
+    <div class="pub-authors"><a href="#">Bhanu Prakash Vangala</a>, Tanu Malik</div>
+    <div class="pub-links">
+      <span class="pub-link-disabled">Preprint (coming soon)</span>
+      <span class="pub-link-disabled">Code (coming soon)</span>
+      <span class="pub-venue">Under Review at IEEE CLOUD 2026</span>
+    </div>
+  </div>
+</div>
+
+<div class="pub-card">
+  <div class="pub-img">
+    <img src="images/AdaptiveLLMaaS.png" alt="Beyond Functional Correctness">
+  </div>
+  <div class="pub-content">
+    <div class="pub-title">Beyond Functional Correctness: Evaluating AI-Generated Software Services</div>
+    <div class="pub-authors"><a href="#">Bhanu Prakash Vangala</a>, Ashish Gehani, Tanu Malik</div>
+    <div class="pub-links">
+      <span class="pub-link-disabled">Preprint (coming soon)</span>
+      <span class="pub-link-disabled">Code (coming soon)</span>
+      <span class="pub-venue">Under Review at ACM REP 2026</span>
     </div>
   </div>
 </div>

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,6 +1,9 @@
 # 🔥 News
 - *2026.02*: 🎤 My presentation on **"Evaluating Dependency Gaps in LLM-Generated Code"** was selected for the **Sixth Chameleon User Meeting** (April 15–16, 2026) at NCAR’s Mesa Lab in Boulder, Colorado.
 - *2026.01*: 🇸🇬 I presented **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** (Jan 26) and **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** (Jan 27) at **AAAI 2026** in Singapore.
+- *2026.01*: 📝 Submitted **"The Environment Specification Gap"** (extended 1,000-instance study) to **TMLR**.
+- *2026.01*: 📝 Submitted **"Resource-Aware Multi-Model Serving for GPU Cloud Infrastructure"** to **IEEE CLOUD 2026**.
+- *2026.01*: 📝 Submitted **"Beyond Functional Correctness: Evaluating AI-Generated Software Services"** to **ACM REP 2026**.
 - *2025.12*: 🎉 Our paper **"AI-Generated Code Is Not Reproducible (Yet): An Empirical Study of Dependency Gaps in LLM-Based Coding Agents"** was accepted at the **RAI 2025 workshop**.
 - *2025.11*: 🎉 Our paper **"Efficient Multi-Model Orchestration for Self-Hosted Large Language Models"** was accepted at the **Deployable Artificial Intelligence (DAI2025) Workshop**.
 - *2025.05*: 🎓 I graduated with my **M.S. in Computer Science** and continued to pursue my **Ph.D. in Computer Science at Mizzou**.

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -125,6 +125,7 @@
 
 ## 🎯 Under Review / In Preparation
 
-- **Self-Correcting LLMs**: Framework for automatic error detection and correction in language model outputs *(Submitting to ACL 2025)*
-- **Factuality Benchmarks**: Comprehensive evaluation suite for scientific domain LLMs *(Preparing for NeurIPS 2025)*
-- **Reproducible AI Containers**: Provenance-tracking containers for collaborative model development *(NASA-funded, targeting ICML 2025)*
+- **The Environment Specification Gap: An Empirical Study of Dependency Misspecification in LLM-Generated Code**  \n  *Bhanu Prakash Vangala, Ashish Gehani, Tanu Malik* — **Under Review (TMLR)**
+- **Resource-Aware Multi-Model Serving for GPU Cloud Infrastructure**  \n  *Bhanu Prakash Vangala, Tanu Malik* — **Under Review (IEEE CLOUD 2026)**
+- **Beyond Functional Correctness: Evaluating AI-Generated Software Services**  \n  *Bhanu Prakash Vangala, Ashish Gehani, Tanu Malik* — **Under Review (ACM REP 2026)**
+- **Evaluating Multiple Agentic-AI Interaction on Bare-Metal Machines**  \n  *Bhanu Prakash Vangala, Ashish Gehani, Tanu Malik* — **Chameleon Cloud User Meeting 2026**


### PR DESCRIPTION
### Motivation
- Remove an incorrect co-advisor mention so the About page reflects the current advisor relationship accurately. 
- Surface recent under-review manuscripts and submission status so the public portfolio and news are complete and consistent. 
- Keep include fragments in sync so the homepage and the includes-based sections display the same content. 

### Description
- Updated `_pages/about.md` to remove Dr. Jianlin Cheng from the advisor sentence and to add three under-review publication entries in a new `Under Review (2026)` block. 
- Updated `_pages/includes/news.md` to add three news items announcing the TMLR / IEEE CLOUD 2026 / ACM REP 2026 submissions. 
- Updated `_pages/includes/pub.md` to replace generic placeholders with explicit under-review entries for the current manuscripts. 
- Committed changes with message "Update advisor info and add missing under-review/news entries"; affected files: `_pages/about.md`, `_pages/includes/news.md`, `_pages/includes/pub.md`. 

### Testing
- Ran `git status --short`, `git diff` and `git commit` which completed successfully and confirmed the three files were staged and committed. 
- Attempted `bundle exec jekyll build` which failed because the environment is missing the `jekyll` gem executable (Bundler not installed), so site build verification could not be performed here. 
- Confirmed the in-repo Markdown/HTML diffs show the intended textual and include updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e923a5a268833196754a63801e5699)