### PR TITLE
Fix the reveal bug, rebuild the hero, split the homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ author:
 #   generated answers. NEVER put an API key here -- this file is public.
 assistant:
   enabled                : true
-  endpoint               : ""
+  endpoint               : "https://bhanuprakashvangala-github-io.vercel.app/api/chat"
   model                  : "gpt-oss"
 
 # Reading Files

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -30,7 +30,7 @@ profile:
   phone: "+1 (573) 639-3768"
   show_phone: false
   avatar: "images/Bhanu1.jpg"
-  tagline: "When trust, reproducibility, and efficiency are the same problem."
+  tagline: "Trust, reproducibility and efficiency turn out to be one problem."
   summary: >-
     I work where machine learning meets the messy reality of the systems that have
     to run it. One question keeps pulling me back. When an AI pipeline hands you a
@@ -42,7 +42,7 @@ profile:
     its dependencies or its resource use, someone outside the team that built it
     ought to be able to check.
   dissertation: "Executable Reliability for AI Systems"
-  dissertation_sub: "When trust, reproducibility, and efficiency are the same problem"
+  dissertation_sub: "Trust, reproducibility and efficiency turn out to be one problem"
   area: "AI, Systems & Networking"
   interests:
     - "Agentic AI systems"
@@ -270,6 +270,7 @@ publications:
       works.
 
   - id: pick-and-spin
+    featured: true
     ref: 4
     year: 2026
     title: "Resource-Aware Multi-Model Serving for GPU Cloud Infrastructure (Pick-and-Spin)"
@@ -296,6 +297,7 @@ publications:
       behind the Model Router demo on this site.
 
   - id: not-reproducible
+    featured: true
     ref: 5
     year: 2026
     title: "AI-Generated Code Is Not Reproducible (Yet): Dependency Gaps in Coding Agents"
@@ -358,6 +360,7 @@ publications:
       instead of holding hardware indefinitely.
 
   - id: hallumat
+    featured: true
     ref: 8
     year: 2025
     title: "HalluMat: Detecting Hallucinations in LLM-Generated Materials Science Content Through Multi-Stage Verification"
@@ -569,6 +572,7 @@ research:
 # -----------------------------------------------------------------------------
 projects:
   - id: learnllm
+    featured: true
     title: "LearnLLM.dev"
     role: "Founder"
     status: "Live"
@@ -592,6 +596,7 @@ projects:
       Hackathon 2025.
 
   - id: reflectmemory
+    featured: true
     title: "ReflectMemory: persistent memory for long-context reasoning"
     status: "Prototype"
     tags: [agents, memory]
@@ -609,6 +614,7 @@ projects:
       with a Kotlin app giving turn-by-turn guidance indoors where GPS fails.
 
   - id: chatmed
+    featured: true
     title: "ChatMed: grounded medical question answering"
     status: "Completed"
     tags: [nlp, medical]

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,28 +1,20 @@
-# Main navigation. Anchor targets live on the homepage; /demos/ and /cv/ are
-# standalone pages. `spy: true` opts a link into scroll-spy highlighting.
+# Main navigation. Four items, deliberately: the previous nine competed with
+# each other and none of them read as the primary path.
 #
-# The order here has to match the order the sections appear on the homepage,
-# or the scroll-spy highlight jumps backwards as you scroll.
+# Anchor targets live on the homepage; /publications/ and /cv/ are standalone
+# pages. `spy: true` opts a link into scroll-spy highlighting, which only makes
+# sense for the two that point at homepage sections.
+#
+# /projects/, /news/ and /demos/ are reachable from their homepage sections and
+# from the hero links rather than from the nav.
 main:
   - title: "About"
     url: "/#about-me"
     spy: true
-  - title: "News"
-    url: "/#news"
-    spy: true
-  - title: "Experience"
-    url: "/#experience"
+  - title: "Research"
+    url: "/#research-threads"
     spy: true
   - title: "Publications"
-    url: "/#publications"
-    spy: true
-  - title: "Projects"
-    url: "/#projects"
-    spy: true
-  - title: "Awards"
-    url: "/#honors-and-awards"
-    spy: true
-  - title: "Demos"
-    url: "/demos/"
+    url: "/publications/"
   - title: "CV"
     url: "/cv/"

--- a/_includes/news-feed.html
+++ b/_includes/news-feed.html
@@ -1,0 +1,8 @@
+{%- comment -%}
+  News list. include.items is the list to render.
+{%- endcomment -%}
+<ol class="news-feed" id="news-feed">
+{%- for n in include.items %}
+<li class="news-item"><span class="news-date">{{ n.date }}</span><span class="news-body">{{ n.text | markdownify | remove: '<p>' | remove: '</p>' | strip }}</span></li>
+{%- endfor %}
+</ol>

--- a/_includes/project-grid.html
+++ b/_includes/project-grid.html
@@ -1,0 +1,18 @@
+{%- comment -%}
+  Project cards. include.items is the list to render.
+{%- endcomment -%}
+<ul class="project-grid">
+{%- for pr in include.items %}
+<li class="project-card">
+<h3 class="project-title">{{ pr.title }}</h3>
+<p class="project-meta">{% if pr.role %}<span class="badge is-accent">{{ pr.role }}</span>{% endif %}<span class="badge is-muted">{{ pr.status }}</span></p>
+<p class="project-desc">{{ pr.desc }}</p>
+{%- if pr.stack %}
+<p class="project-tags">{% assign bits = pr.stack | split: "|" %}{% for b in bits %}<span class="tag">{{ b | strip }}</span>{% endfor %}</p>
+{%- endif %}
+{%- if pr.links %}
+<p class="project-links">{% for l in pr.links %}<a class="btn-link" href="{{ l.url }}">{{ l.label }}</a>{% endfor %}</p>
+{%- endif %}
+</li>
+{%- endfor %}
+</ul>

--- a/_includes/pub-list.html
+++ b/_includes/pub-list.html
@@ -1,0 +1,45 @@
+{%- comment -%}
+  Publication list. Shared by the homepage (a featured subset) and /publications/
+  (everything), so the two can never drift apart.
+
+  include.items   the publications to render
+  include.filters truthy to render the topic filter bar (full page only)
+{%- endcomment -%}
+{%- if include.filters %}
+<div class="filter-bar" role="group" aria-label="Filter publications by topic">
+{%- for f in site.data.cv.pub_filters %}
+<button type="button" class="filter-chip{% if f.id == 'all' %} is-active{% endif %}" data-filter="{{ f.id }}" aria-pressed="{% if f.id == 'all' %}true{% else %}false{% endif %}">{{ f.label }}</button>
+{%- endfor %}
+<span class="filter-count" id="filter-count" aria-live="polite"></span>
+</div>
+{%- endif %}
+
+<ol class="pub-list" id="pub-list">
+{%- for pub in include.items %}
+<li class="pub" data-tags="{{ pub.tags | join: ' ' }}" data-year="{{ pub.year }}" id="pub-{{ pub.id }}">
+{%- if pub.image %}
+<div class="pub-thumb"><img src="{{ pub.image | prepend: '/' | relative_url }}" alt="" loading="lazy" decoding="async"></div>
+{%- endif %}
+<div class="pub-body">
+<h3 class="pub-title">{{ pub.title }}</h3>
+<p class="pub-authors">{% for a in pub.authors %}{% if a contains 'Bhanu' %}<span class="me">{{ a }}</span>{% else %}{{ a }}{% endif %}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+{%- if pub.highlights %}
+<p>{{ pub.highlights }}</p>
+{%- endif %}
+<p class="pub-meta">
+<span class="pub-venue is-{{ pub.status }}">{% if pub.status == 'review' %}Under review &middot; {% endif %}{{ pub.venue }}{% if pub.kind %} &middot; {{ pub.kind }}{% endif %}</span>
+<span class="pub-tags">{% for t in pub.tags %}<span class="pub-tag">{{ t }}</span>{% endfor %}</span>
+</p>
+{%- if pub.summary %}
+<details class="pub-summary"><summary>What it's about</summary><p>{{ pub.summary }}</p></details>
+{%- endif %}
+{%- if pub.links and pub.links != empty %}
+<p class="pub-actions">{% for l in pub.links %}<a class="btn-link" href="{{ l.url }}">{{ l.label }}</a>{% endfor %}</p>
+{%- endif %}
+</div>
+</li>
+{%- endfor %}
+</ol>
+{%- if include.filters %}
+<p class="callout is-note is-hidden" id="pub-empty">No publications match that filter.</p>
+{%- endif %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,63 +12,38 @@ redirect_from:
 {%- assign p = cv.profile -%}
 
 <section id="about-me" class="section hero" aria-labelledby="hero-name">
-<div class="hero-grid">
-<div class="hero-col">
+
+<div class="hero-lede">
 <img class="hero-portrait" src="{{ p.avatar | prepend: '/' | relative_url }}" alt="Portrait of {{ p.name }}" width="132" height="132" fetchpriority="high">
 <h1 class="hero-name" id="hero-name">{{ p.name }}</h1>
 <p class="hero-role">{{ p.role }}</p>
-<p class="hero-thesis">{{ p.dissertation_sub }}</p>
-<p class="hero-affil">{{ p.department }} &middot; <a href="https://engineering.missouri.edu/departments/eecs/">{{ p.affiliation }}</a> &middot; {{ p.location }}</p>
-<p class="muted">Advised by <a href="{{ p.advisor_url }}">{{ p.advisor }}</a>. Ph.D. expected June 2027.</p>
-<p class="tag-row" aria-label="Highlights">
-{%- for b in p.badges %}<span class="badge is-accent">{{ b }}</span>{% endfor %}
-</p>
+<p class="hero-thesis">{{ p.dissertation_sub }}.</p>
 <div class="link-pills hero-actions">
-{%- for l in cv.links %}
+{%- assign primary = "scholar,github,cv" | split: "," %}
+{%- for id in primary %}{% assign l = cv.links | where: "id", id | first %}{% if l %}
 <a class="link-pill{% if l.id == 'cv' %} link-pill--primary{% endif %}" href="{% if l.url contains '://' or l.url contains 'mailto:' %}{{ l.url }}{% else %}{{ l.url | relative_url }}{% endif %}"><i class="{{ l.icon }}" aria-hidden="true"></i> {{ l.label }}</a>
-{%- endfor %}
-<a class="link-pill" href="{{ '/demos/' | relative_url }}"><i class="fas fa-flask" aria-hidden="true"></i> Live demos</a>
-</div>
-</div>
-<div class="hero-col hero-col--term">
-<div class="terminal" id="terminal" role="group" aria-label="Interactive shell over the CV">
-<div class="term-bar" aria-hidden="true">
-<span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
-<span class="term-title">bhanu@nautilus: ~</span>
-</div>
-<div class="term-out" id="term-out" role="log" aria-live="polite"></div>
-<div class="term-chips">
-<button type="button" class="term-chip" data-cmd="ls">ls</button>
-<button type="button" class="term-chip" data-cmd="cat about.txt">cat about.txt</button>
-<button type="button" class="term-chip" data-cmd="cd papers">cd papers</button>
-<button type="button" class="term-chip" data-cmd="tree">tree</button>
-<button type="button" class="term-chip" data-cmd="help">help</button>
-</div>
-<label class="term-row" for="term-input">
-<span class="term-prompt"><span class="t-prompt">bhanu@nautilus</span> <span class="term-prompt-path t-path">~/</span> <span class="t-caret">$</span></span>
-<input class="term-input" id="term-input" type="text" autocomplete="off" autocapitalize="off"
-       autocorrect="off" spellcheck="false" aria-label="Terminal input">
-</label>
-</div>
+{%- endif %}{% endfor %}
 </div>
 </div>
 
 <div class="hero-below">
+<div class="hero-below-main">
 <p class="hero-summary">{{ p.summary }}</p>
-<p class="muted"><strong>Research interests:</strong> {{ p.interests | join: " &middot; " }}</p>
 </div>
-
-<ul class="stat-grid">
-{%- for s in cv.stats %}
-{%- assign n = s.num -%}
-{%- if s.count == "publications" -%}
-  {%- assign n = cv.publications | where_exp: "p", "p.ref" | size -%}
-{%- elsif s.count == "orals" -%}
-  {%- assign n = cv.publications | where: "kind", "Oral" | size -%}
-{%- endif -%}
-<li class="stat"><span class="stat-num">{{ n }}</span><span class="stat-label">{{ s.label }}</span></li>
-{%- endfor %}
-</ul>
+<div class="hero-below-meta">
+<p class="hero-affil">{{ p.department }} &middot; <a href="https://engineering.missouri.edu/departments/eecs/">{{ p.affiliation }}</a> &middot; {{ p.location }}. Advised by <a href="{{ p.advisor_url }}">{{ p.advisor }}</a>. Ph.D. expected June 2027.</p>
+<p class="muted"><strong>Research interests:</strong> {{ p.interests | join: " &middot; " }}</p>
+<p class="tag-row" aria-label="Funders and honours">
+{%- for b in p.badges %}<span class="badge is-accent">{{ b }}</span>{% endfor %}
+</p>
+<div class="link-pills">
+{%- for l in cv.links %}{% unless l.id == 'scholar' or l.id == 'github' or l.id == 'cv' %}
+<a class="link-pill" href="{% if l.url contains '://' or l.url contains 'mailto:' %}{{ l.url }}{% else %}{{ l.url | relative_url }}{% endif %}"><i class="{{ l.icon }}" aria-hidden="true"></i> {{ l.label }}</a>
+{%- endunless %}{% endfor %}
+<a class="link-pill" href="{{ '/demos/' | relative_url }}"><i class="fas fa-flask" aria-hidden="true"></i> Live demos</a>
+</div>
+</div>
+</div>
 </section>
 
 <section id="research-threads" class="section" aria-labelledby="threads-title">
@@ -90,16 +65,40 @@ redirect_from:
 </ol>
 </section>
 
+<section id="explore" class="section" aria-labelledby="explore-title">
+<div class="section-head"><h2 class="section-title" id="explore-title">Poke around yourself</h2></div>
+<p class="section-sub">A real shell over this CV. It reads the same knowledge base the assistant answers from, so it cannot tell you anything the rest of the site does not. Try <code>ls</code>, <code>cat papers/pick-and-spin.md</code>, or <code>ask what is pick and spin</code>.</p>
+
+<div class="terminal" id="terminal" role="group" aria-label="Interactive shell over the CV">
+<div class="term-bar" aria-hidden="true">
+<span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
+<span class="term-title">bhanu@nautilus: ~</span>
+</div>
+<div class="term-out" id="term-out" role="log" aria-live="polite"></div>
+<div class="term-chips">
+<button type="button" class="term-chip" data-cmd="ls">ls</button>
+<button type="button" class="term-chip" data-cmd="cat about.txt">cat about.txt</button>
+<button type="button" class="term-chip" data-cmd="cd papers">cd papers</button>
+<button type="button" class="term-chip" data-cmd="tree">tree</button>
+<button type="button" class="term-chip" data-cmd="help">help</button>
+</div>
+<label class="term-row" for="term-input">
+<span class="term-prompt"><span class="t-prompt">bhanu@nautilus</span> <span class="term-prompt-path t-path">~/</span> <span class="t-caret">$</span></span>
+<input class="term-input" id="term-input" type="text" autocomplete="off" autocapitalize="off"
+       autocorrect="off" spellcheck="false" aria-label="Terminal input">
+</label>
+</div>
+</section>
+
+
 <section id="news" class="section" aria-labelledby="news-title">
-<div class="section-head"><h2 class="section-title" id="news-title">News</h2></div>
+<div class="section-head">
+<h2 class="section-title" id="news-title">News</h2>
+<a class="section-action" href="{{ '/news/' | relative_url }}">All {{ cv.news | size }} updates &rarr;</a>
+</div>
 
-<ol class="news-feed" id="news-feed">
-{%- for n in cv.news %}
-<li class="news-item"><span class="news-date">{{ n.date }}</span><span class="news-body">{{ n.text | markdownify | remove: '<p>' | remove: '</p>' | strip }}</span></li>
-{%- endfor %}
-</ol>
-
-<button type="button" class="news-more" id="news-more" aria-expanded="false" aria-controls="news-feed">Show all {{ cv.news | size }} updates</button>
+{%- assign recent_news = cv.news | slice: 0, 5 %}
+{% include news-feed.html items=recent_news %}
 </section>
 
 <section id="experience" class="section" aria-labelledby="exp-title">
@@ -128,45 +127,13 @@ redirect_from:
 
 <section id="publications" class="section" aria-labelledby="pubs-title">
 <div class="section-head">
-<h2 class="section-title" id="pubs-title">Publications</h2>
-<a class="section-action" href="https://scholar.google.com/citations?user=qHBOnpkAAAAJ&amp;hl=en">Google Scholar &rarr;</a>
+<h2 class="section-title" id="pubs-title">Selected papers</h2>
+<a class="section-action" href="{{ '/publications/' | relative_url }}">All {{ cv.publications | size }} publications &rarr;</a>
 </div>
-<p class="section-sub">Mine is the name in <span class="me">bold</span>. Filter by topic if you want a narrower slice.</p>
+<p class="section-sub">One per thread. Mine is the name in <span class="me">bold</span>.</p>
 
-<div class="filter-bar" role="group" aria-label="Filter publications by topic">
-{%- for f in cv.pub_filters %}
-<button type="button" class="filter-chip{% if f.id == 'all' %} is-active{% endif %}" data-filter="{{ f.id }}" aria-pressed="{% if f.id == 'all' %}true{% else %}false{% endif %}">{{ f.label }}</button>
-{%- endfor %}
-<span class="filter-count" id="filter-count" aria-live="polite"></span>
-</div>
-
-<ol class="pub-list" id="pub-list">
-{%- for pub in cv.publications %}
-<li class="pub" data-tags="{{ pub.tags | join: ' ' }}" data-year="{{ pub.year }}" id="pub-{{ pub.id }}">
-{%- if pub.image %}
-<div class="pub-thumb"><img src="{{ pub.image | prepend: '/' | relative_url }}" alt="" loading="lazy" decoding="async"></div>
-{%- endif %}
-<div class="pub-body">
-<h3 class="pub-title">{{ pub.title }}</h3>
-<p class="pub-authors">{% for a in pub.authors %}{% if a contains 'Bhanu' %}<span class="me">{{ a }}</span>{% else %}{{ a }}{% endif %}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
-{%- if pub.highlights %}
-<p>{{ pub.highlights }}</p>
-{%- endif %}
-<p class="pub-meta">
-<span class="pub-venue is-{{ pub.status }}">{% if pub.status == 'review' %}Under review &middot; {% endif %}{{ pub.venue }}{% if pub.kind %} &middot; {{ pub.kind }}{% endif %}</span>
-<span class="pub-tags">{% for t in pub.tags %}<span class="pub-tag">{{ t }}</span>{% endfor %}</span>
-</p>
-{%- if pub.summary %}
-<details class="pub-summary"><summary>What it's about</summary><p>{{ pub.summary }}</p></details>
-{%- endif %}
-{%- if pub.links and pub.links != empty %}
-<p class="pub-actions">{% for l in pub.links %}<a class="btn-link" href="{{ l.url }}">{{ l.label }}</a>{% endfor %}</p>
-{%- endif %}
-</div>
-</li>
-{%- endfor %}
-</ol>
-<p class="callout is-note is-hidden" id="pub-empty">No publications match that filter.</p>
+{%- assign featured_pubs = cv.publications | where: "featured", true %}
+{% include pub-list.html items=featured_pubs %}
 </section>
 
 <section id="research" class="section" aria-labelledby="research-title">
@@ -190,23 +157,13 @@ redirect_from:
 </section>
 
 <section id="projects" class="section" aria-labelledby="projects-title">
-<div class="section-head"><h2 class="section-title" id="projects-title">Projects</h2></div>
+<div class="section-head">
+<h2 class="section-title" id="projects-title">Selected projects</h2>
+<a class="section-action" href="{{ '/projects/' | relative_url }}">All projects &rarr;</a>
+</div>
 
-<ul class="project-grid">
-{%- for pr in cv.projects %}
-<li class="project-card">
-<h3 class="project-title">{{ pr.title }}</h3>
-<p class="project-meta">{% if pr.role %}<span class="badge is-accent">{{ pr.role }}</span>{% endif %}<span class="badge is-muted">{{ pr.status }}</span></p>
-<p class="project-desc">{{ pr.desc }}</p>
-{%- if pr.stack %}
-<p class="project-tags">{% assign bits = pr.stack | split: "|" %}{% for b in bits %}<span class="tag">{{ b | strip }}</span>{% endfor %}</p>
-{%- endif %}
-{%- if pr.links %}
-<p class="project-links">{% for l in pr.links %}<a class="btn-link" href="{{ l.url }}">{{ l.label }}</a>{% endfor %}</p>
-{%- endif %}
-</li>
-{%- endfor %}
-</ul>
+{%- assign featured_projects = cv.projects | where: "featured", true %}
+{% include project-grid.html items=featured_projects %}
 </section>
 
 <section id="honors-and-awards" class="section" aria-labelledby="awards-title">

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -1,0 +1,17 @@
+---
+permalink: /news/
+title: "News"
+excerpt: "Talks, awards, acceptances and other updates."
+author_profile: false
+---
+
+{%- assign cv = site.data.cv -%}
+
+<section class="section" aria-labelledby="news-title">
+<div class="section-head"><h2 class="section-title" id="news-title">News archive</h2></div>
+<p class="section-sub">Everything, newest first. The homepage carries only the last few.</p>
+
+{% include news-feed.html items=cv.news %}
+
+<p class="muted"><a href="{{ '/' | relative_url }}">&larr; Back to the homepage</a></p>
+</section>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,18 @@
+---
+permalink: /projects/
+title: "Projects"
+excerpt: "Systems and tools built by Bhanu Prakash Vangala."
+author_profile: false
+---
+
+{%- assign cv = site.data.cv -%}
+{%- assign projects = cv.projects | where_exp: "p", "p.desc" -%}
+
+<section class="section" aria-labelledby="projects-title">
+<div class="section-head"><h2 class="section-title" id="projects-title">Projects</h2></div>
+<p class="section-sub">Things I have built, mostly to answer a question the papers raised.</p>
+
+{% include project-grid.html items=projects %}
+
+<p class="muted"><a href="{{ '/' | relative_url }}">&larr; Back to the homepage</a></p>
+</section>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,20 @@
+---
+permalink: /publications/
+title: "Publications"
+excerpt: "Peer-reviewed papers, preprints and theses by Bhanu Prakash Vangala."
+author_profile: false
+---
+
+{%- assign cv = site.data.cv -%}
+
+<section class="section" aria-labelledby="pubs-title">
+<div class="section-head">
+<h2 class="section-title" id="pubs-title">Publications</h2>
+<a class="section-action" href="https://scholar.google.com/citations?user=qHBOnpkAAAAJ&amp;hl=en">Google Scholar &rarr;</a>
+</div>
+<p class="section-sub">Mine is the name in <span class="me">bold</span>. Filter by topic if you want a narrower slice.</p>
+
+{% include pub-list.html items=cv.publications filters=true %}
+
+<p class="muted"><a href="{{ '/' | relative_url }}">&larr; Back to the homepage</a></p>
+</section>

--- a/_sass/_audit.scss
+++ b/_sass/_audit.scss
@@ -1,0 +1,173 @@
+/* ==========================================================================
+   AUDIT
+   --------------------------------------------------------------------------
+   Fixes from a review of the deployed site. Loaded last, so it can correct
+   earlier layers without editing them.
+
+   ASCII only. libsass evaluates clamp/min/max arguments as Sass arithmetic
+   and fails on mixed vw and rem units, so those values are interpolated to
+   pass through literally.
+   ========================================================================== */
+
+
+/* --------------------------------------------------------------------------
+   1. Floating widgets stop sitting on the text.
+
+   Measured at 1440: the content column ran 32..1408, the assistant launcher
+   was a 182px pill at 1234..1416 and the back-to-top button sat at 20..64.
+   Both were inside the column, and the launcher covered thread copy by
+   roughly 7,000 square pixels at several scroll positions.
+
+   Two changes. The launcher keeps the compact circular form it already used
+   below 640px, at every width, which takes it from 182px to 56px. And the
+   page reserves a gutter wider than either widget, so no line of text ever
+   enters the band they occupy.
+   -------------------------------------------------------------------------- */
+
+@media (min-width: 640px) {
+  .ai-launcher {
+    width: 56px;
+    min-width: 56px;
+    height: 56px;
+    min-height: 56px;
+    padding: 0;
+    gap: 0;
+  }
+
+  /* The label is what made it a pill. The button keeps its accessible name
+     from aria-label, so removing the visible text costs nothing to a screen
+     reader. */
+  .ai-launcher .ai-launcher-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
+/* A flat 88px, not a clamp. The launcher needs 80px of clearance (56px wide,
+   24px from the edge) at every width, and a vw-based value dipped to 72px at
+   1440 and 77px at 1280, which put the button back over the last few pixels
+   of the column. A fixed value is the only one that always clears. */
+@media (min-width: 900px) {
+  #main {
+    padding-left: 5.5rem;
+    padding-right: 5.5rem;
+  }
+}
+
+
+/* --------------------------------------------------------------------------
+   2. News is a single column.
+
+   It was flowing into as many 26rem columns as fit, which with five items
+   left four on the left and one stranded on the right. A dated list reads
+   top to bottom; balancing it across columns fights that.
+   -------------------------------------------------------------------------- */
+
+.news-feed,
+.page__content ol.news-feed {
+  -webkit-columns: auto;
+  columns: auto;
+  -webkit-column-count: 1;
+  column-count: 1;
+}
+
+
+/* --------------------------------------------------------------------------
+   3. The hero.
+
+   What used to be above the fold: a three-line serif name, seven credential
+   chips, seven link buttons and a terminal panel that was mostly empty. A
+   reader met fourteen pills before a single sentence saying what the work is,
+   and the fold cut through the affiliation line.
+
+   The lede is now name, role, one thesis sentence and three links. Everything
+   else moved below it, and the terminal moved out of the hero entirely into
+   its own section, where it boots into `ls` instead of restating the chips.
+   -------------------------------------------------------------------------- */
+
+.hero {
+  min-height: 0;
+}
+
+.hero-lede {
+  max-width: #{"min(100%, 34rem)"};
+}
+
+/* The lede owns the fold on a desktop screen. Without this the supporting
+   column rose beside it and put seven credential chips back above the fold,
+   which is the thing the rebuild was meant to stop. Width-scoped, because on a
+   phone a viewport-tall lede is just a long empty scroll. */
+@media (min-width: 900px) {
+  .hero-lede {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    min-height: #{"calc(100vh - 11rem)"};
+  }
+}
+
+.hero-lede .hero-portrait {
+  margin-bottom: var(--space-4, 1rem);
+}
+
+/* Two lines at most. The old cap let it break into three at wide widths and
+   pushed everything under it past the fold. */
+.hero-lede .hero-name {
+  font-size: #{"clamp(2.25rem, 1.1rem + 4vw, 4.25rem)"};
+  margin-bottom: var(--space-3, 0.75rem);
+  text-wrap: balance;
+}
+
+.hero-lede .hero-role {
+  margin-bottom: var(--space-2, 0.5rem);
+}
+
+.hero-lede .hero-thesis {
+  max-width: #{"min(100%, 46ch)"};
+  margin-bottom: var(--space-5, 1.25rem);
+}
+
+.hero-lede .hero-actions {
+  margin: 0;
+}
+
+/* The supporting material. It reads as a second beat rather than competing
+   with the lede for the fold, and it runs in two columns on a wide screen so
+   the width the lede does not use is filled with substance instead of a gap. */
+.hero-below {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(#{"min(100%, 24rem)"}, 1fr));
+  gap: #{"clamp(1.5rem, 3vw, 3rem)"};
+  align-items: start;
+  margin-top: #{"clamp(2rem, 3.5vw, 3.5rem)"};
+}
+
+.hero-below .hero-summary {
+  max-width: #{"min(100%, 68ch)"};
+  margin: 0;
+}
+
+/* Every block in the meta column had margin: 0 from one layer or another, so
+   the summary ran straight into the affiliation line with no gap at all. */
+.hero-below-meta > * {
+  margin: 0;
+}
+
+.hero-below-meta > * + * {
+  margin-top: #{"clamp(0.75rem, 1.1vw, 1.25rem)"};
+}
+
+/* The shell is a feature, not decoration, so it gets a section and a height
+   that suits its content rather than a neighbouring column. */
+#explore .terminal {
+  height: #{"clamp(20rem, 46vh, 30rem)"};
+  min-height: 0;
+  max-width: #{"min(100%, 60rem)"};
+}

--- a/_sass/_fluid.scss
+++ b/_sass/_fluid.scss
@@ -208,6 +208,21 @@
 }
 
 
+/* The timeline is the exception in that list. It is prose, not a layout grid,
+   and opting it out of the measure let the Experience bullets run the full
+   1376px, roughly 180 characters a line. The list itself stays full width so
+   the rail and markers keep their alignment; the text inside it does not. */
+.timeline-bullets li,
+.timeline-body p,
+.timeline-item > p,
+.timeline-org,
+.cv-entry-bullets li,
+.hero-below .muted,
+.kv-val {
+  max-width: 74ch;
+}
+
+
 /* --------------------------------------------------------------------------
    4. Intrinsic grids. Column count follows the width available. A 1366 laptop
    gets two publication columns, a 1512 gets three, an ultrawide gets four,
@@ -226,11 +241,61 @@
   }
 }
 
+/* Publications were 36% of the page: 4972px of a 13883px document. Each card
+   ran 651px, and 281px of that was a decorative full-bleed banner holding an
+   image that was itself 427px tall and cropped to fit. Fourteen of those is
+   most of the scroll.
+//
+   The artwork stays, because a wall of grey text was the earlier complaint.
+   It becomes a thumbnail beside the title rather than a banner above it, which
+   takes the card to roughly 280px and the section to about a third of what it
+   was. Flex rather than grid so a publication with no image degrades to a
+   plain text card instead of leaving an empty column. */
 .pub-list .pub {
   display: flex;
-  flex-direction: column;
-  height: 100%;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: #{"clamp(0.85rem, 1.1vw, 1.15rem)"};
+  height: auto;
   margin: 0;
+  padding: #{"clamp(1rem, 1.2vw, 1.35rem)"};
+}
+
+/* The thumb is an old-style ratio box: its height comes from padding-top, not
+   from height, so setting height alone just added to it. Zero the padding and
+   give it real dimensions. */
+.pub-list .pub .pub-thumb {
+  flex: 0 0 #{"clamp(5rem, 6.5vw, 6.5rem)"};
+  width: #{"clamp(5rem, 6.5vw, 6.5rem)"};
+  max-width: none;
+  height: #{"clamp(5rem, 6.5vw, 6.5rem)"};
+  padding-top: 0;
+  margin: 0;
+  border-radius: var(--radius-md, 10px);
+  overflow: hidden;
+  background: var(--c-surface-2, #eef2f7);
+}
+
+/* The image is absolutely positioned inside that box and was set to
+   object-fit: contain with padding, which letterboxed a 427px-tall source into
+   a 66px strip. Cover fills the square instead. */
+.pub-list .pub .pub-thumb img {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.pub-list .pub .pub-body {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .thread-grid {
@@ -280,6 +345,39 @@
 
 
 /* --------------------------------------------------------------------------
+   4b. Vertical rhythm and stray images. The page ran 13,883px, over fifteen
+   screens. Three things were doing it, and none of them were content.
+   -------------------------------------------------------------------------- */
+
+/* Every section carried 73px of top padding plus 64px of bottom margin, so
+   137px sat between each pair. Across eleven sections that is 1,370px of the
+   scroll spent on nothing. */
+.page__content > .section {
+  padding-top: #{"clamp(2rem, 1.1rem + 2.1vw, 3.75rem)"};
+  margin-bottom: #{"clamp(0.75rem, 1.2vw, 1.75rem)"};
+}
+
+/* The 68px cap on award thumbnails is nested under `.award`, so the talks
+   photo, which sits in a bare `.award-images`, never received it and rendered
+   at its natural 600px. This reaches it while staying weak enough (0,1,1) for
+   the `.award .award-images img` rule (0,3,1) to keep awards at 68px. */
+.award-images img {
+  width: auto;
+  height: #{"clamp(7rem, 10vw, 10.5rem)"};
+  object-fit: cover;
+}
+
+/* Eleven awards stacked single-file is 1,240px. Two columns halves it and the
+   entries are short enough to read side by side. */
+.award-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(#{"min(100%, 24rem)"}, 1fr));
+  gap: #{"clamp(0.5rem, 1vw, 1.1rem)"};
+  -webkit-column-gap: #{"clamp(0.5rem, 1vw, 1.1rem)"};
+}
+
+
+/* --------------------------------------------------------------------------
    5. The terminal sizes to the window it is in, rather than stepping through
    460 / 380 / 320. vh keeps it proportional on a short laptop and a tall
    monitor alike; the rem bounds keep it usable at either extreme.
@@ -318,11 +416,16 @@
    sources and cost nothing to pin down.
    -------------------------------------------------------------------------- */
 
-#main img,
-#main svg,
-#main video,
-#main canvas,
-#main iframe {
+/* No ID here, deliberately. Written as `#main img` this reset carried
+   specificity (1,0,1) and beat every component rule that sets an image
+   height, including the publication thumbnails, whose images then computed to
+   0px tall. A base reset has to be weak enough for components to override, so
+   it stays at (0,0,1). */
+img,
+svg,
+video,
+canvas,
+iframe {
   max-width: 100%;
   height: auto;
 }

--- a/_sass/_motion.scss
+++ b/_sass/_motion.scss
@@ -55,7 +55,12 @@ $mo-z-progress:  70;
 
 /* --------------------------------------------------------------------------
    1. SCROLL REVEALS
-   Contract: elements carry `data-reveal`; the JS adds `.is-revealed` once
+   Contract: the JS adds `.is-armed` to hide an element, then `.is-revealed`
+   to show it. The bare `data-reveal` attribute hides NOTHING on its own, so a
+   script that never runs, or an observer that misses an element, leaves that
+   element visible rather than blank. Previously the attribute did the hiding
+   and whole sections rendered as white space when the observer missed them.
+   Historic note: elements carry `data-reveal`; the JS adds `.is-revealed` once
    they intersect the viewport, and NEVER removes it (reveals are one-way --
    a two-way rule would replay the transition-delay backwards).
 
@@ -65,7 +70,7 @@ $mo-z-progress:  70;
    for reduced motion, for print and for crawlers.
    -------------------------------------------------------------------------- */
 
-html.js-motion [data-reveal] {
+html.js-motion [data-reveal].is-armed {
   /* Declared, not just defaulted, so `var(--reveal-delay)` inside calc() is
      always resolvable. The JS overwrites it inline, in ms, with the unit. */
   --reveal-delay: 0ms;
@@ -80,11 +85,11 @@ html.js-motion [data-reveal] {
 
 /* Direction variants. Same specificity as the base rule (0-1-0), so source
    order decides -- these must stay below it. */
-html.js-motion [data-reveal="up"]    { transform: translate3d(0, $mo-reveal-y, 0); }
-html.js-motion [data-reveal="left"]  { transform: translate3d(-1 * $mo-reveal-x, 0, 0); }
-html.js-motion [data-reveal="right"] { transform: translate3d($mo-reveal-x, 0, 0); }
-html.js-motion [data-reveal="scale"] { transform: scale(0.965); }
-html.js-motion [data-reveal="fade"]  { transform: none; }
+html.js-motion [data-reveal="up"].is-armed    { transform: translate3d(0, $mo-reveal-y, 0); }
+html.js-motion [data-reveal="left"].is-armed  { transform: translate3d(-1 * $mo-reveal-x, 0, 0); }
+html.js-motion [data-reveal="right"].is-armed { transform: translate3d($mo-reveal-x, 0, 0); }
+html.js-motion [data-reveal="scale"].is-armed { transform: scale(0.965); }
+html.js-motion [data-reveal="fade"].is-armed  { transform: none; }
 
 /* The resting state. 0-2-0 beats every variant above regardless of order. */
 html.js-motion [data-reveal].is-revealed {
@@ -522,7 +527,7 @@ html.js-motion .section-title[data-reveal]:after {
   transition-delay: calc(var(--reveal-delay, 0ms) + 140ms);
 }
 
-html.js-motion .section-title[data-reveal]:not(.is-revealed):after {
+html.js-motion .section-title[data-reveal].is-armed:not(.is-revealed):after {
   transform: scaleX(0);
 }
 
@@ -567,8 +572,12 @@ html.js-motion .ai-launcher.is-nudge {
    a keyboard reaches it. Always visible where there is no hover to speak of.
    -------------------------------------------------------------------------- */
 
+/* Faint rather than absent. This is a hover affordance, but "invisible until
+   you happen to hover" is both undiscoverable and indistinguishable from a
+   rendering fault, so it rests at a legible low contrast and comes forward on
+   hover, focus and touch. */
 .copy-bib {
-  opacity: 0;
+  opacity: 0.55;
   transform: translate3d(0, 2px, 0);
   transition:
     opacity          var(--dur, #{$mo-dur}) var(--ease, #{$mo-ease}),
@@ -657,11 +666,11 @@ html.js-motion .copy-bib.is-copied {
    -------------------------------------------------------------------------- */
 
 @media (max-width: 599px) {
-  html.js-motion [data-reveal]        { transform: translate3d(0, 10px, 0); }
-  html.js-motion [data-reveal="up"]   { transform: translate3d(0, 10px, 0); }
-  html.js-motion [data-reveal="left"] { transform: translate3d(-12px, 0, 0); }
-  html.js-motion [data-reveal="right"]{ transform: translate3d(12px, 0, 0); }
-  html.js-motion [data-reveal="fade"] { transform: none; }
+  html.js-motion [data-reveal].is-armed        { transform: translate3d(0, 10px, 0); }
+  html.js-motion [data-reveal="up"].is-armed   { transform: translate3d(0, 10px, 0); }
+  html.js-motion [data-reveal="left"].is-armed { transform: translate3d(-12px, 0, 0); }
+  html.js-motion [data-reveal="right"].is-armed{ transform: translate3d(12px, 0, 0); }
+  html.js-motion [data-reveal="fade"].is-armed { transform: none; }
   html.js-motion [data-reveal].is-revealed { transform: none; }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -64,3 +64,4 @@
 @import "motion";
 @import "bold";
 @import "fluid";
+@import "audit";

--- a/assets/js/motion.js
+++ b/assets/js/motion.js
@@ -53,14 +53,26 @@
   /* ======================================================================= *
    * 2. Scroll reveals, staggered within each group
    * ======================================================================= */
+  /* The reveal is progressive enhancement, and the CSS reflects that: an
+     element is hidden only while it carries `.is-armed`, a class this function
+     adds. Nothing is hidden by markup, by the `data-reveal` attribute alone,
+     or by a stylesheet loading before the script. If this function never runs,
+     the page renders in full.
+     
+     The previous version hid on the attribute itself and relied entirely on
+     one IntersectionObserver to undo it, so anything the observer missed
+     stayed invisible permanently. Publications rendered as blank white space.
+     Three things stop that from recurring:
+     
+       1. Anything already at or above the fold is revealed outright and never
+          armed, so a first paint can never be blank.
+       2. A throttled scroll and resize pass reveals armed elements that have
+          come into view, independently of the observer.
+       3. A final timer reveals whatever is left. Late is survivable;
+          invisible is not. */
   function initReveals() {
     var targets = $$('[data-reveal]');
     if (!targets.length) return;
-
-    if (!('IntersectionObserver' in window)) {
-      targets.forEach(function (el) { el.classList.add('is-revealed'); });
-      return;
-    }
 
     // Stagger by position within the parent, capped so long lists do not
     // leave the reader waiting on the last item.
@@ -72,15 +84,96 @@
       el.style.setProperty('--reveal-delay', Math.min(i, 8) * 55 + 'ms');
     });
 
+    var armed = [];
+
+    function reveal(el) {
+      el.classList.remove('is-armed');
+      el.classList.add('is-revealed');
+    }
+
+    function revealAll() {
+      armed.forEach(reveal);
+      armed.length = 0;
+    }
+
+    // Only arm what is genuinely below the fold. Everything else is shown as
+    // it is: there is no animation to be had for content the reader is
+    // already looking at, and no way for it to be missed.
+    var fold = window.innerHeight || document.documentElement.clientHeight;
+    targets.forEach(function (el) {
+      // Strictly below the fold. An element merely touching the bottom edge
+      // is on screen at first paint, and arming it makes the first thing the
+      // reader sees a gap.
+      if (el.getBoundingClientRect().top < fold) { el.classList.add('is-revealed'); return; }
+      el.classList.add('is-armed');
+      armed.push(el);
+    });
+
+    if (!armed.length) return;
+
+    if (!('IntersectionObserver' in window)) { revealAll(); return; }
+
     var io = new IntersectionObserver(function (entries) {
       entries.forEach(function (e) {
         if (!e.isIntersecting) return;
-        e.target.classList.add('is-revealed');
+        reveal(e.target);
+        var i = armed.indexOf(e.target);
+        if (i !== -1) armed.splice(i, 1);
         io.unobserve(e.target);
       });
     }, { rootMargin: '0px 0px -8% 0px', threshold: 0.06 });
 
-    targets.forEach(function (el) { io.observe(el); });
+    armed.slice().forEach(function (el) { io.observe(el); });
+
+    // Second, independent pass. The observer is the nice path; this is the
+    // one that guarantees the reader never meets a blank screen.
+    var ticking = false;
+    function sweep() {
+      ticking = false;
+      if (!armed.length) { teardown(); return; }
+      var h = window.innerHeight || document.documentElement.clientHeight;
+      for (var i = armed.length - 1; i >= 0; i--) {
+        var r = armed[i].getBoundingClientRect();
+        if (r.top < h && r.bottom > 0) {
+          io.unobserve(armed[i]);
+          reveal(armed[i]);
+          armed.splice(i, 1);
+        }
+      }
+    }
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(sweep);
+    }
+    function teardown() {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (timer) { clearTimeout(timer); timer = null; }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+
+    // One sweep on the next frame. Layout can still shift between arming and
+    // first paint (a late web font, an image settling), and this catches
+    // anything that ended up on screen after it did.
+    window.requestAnimationFrame(sweep);
+
+    // Last resort. If the reader has not reached them by now something is
+    // wrong with our assumptions, and showing them plainly beats hiding them.
+    var timer = setTimeout(function () {
+      io.disconnect();
+      revealAll();
+      teardown();
+    }, 8000);
+
+    // Printing and find-in-page must never hit hidden text.
+    if (window.matchMedia) {
+      var pm = window.matchMedia('print');
+      if (pm.addEventListener) pm.addEventListener('change', revealAll);
+    }
+    window.addEventListener('beforeprint', revealAll);
   }
 
   /* ======================================================================= *

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -101,6 +101,19 @@
         if (!visible[el.getAttribute('data-spy-for')]) return;
         if (!best || el.getBoundingClientRect().top < best.getBoundingClientRect().top) best = el;
       });
+
+      // Nothing spied is on screen. Since the nav was trimmed to four items,
+      // only two of them point at homepage sections, and both sit near the
+      // top: without this the highlight simply vanished for most of the page.
+      // Fall back to the last section the reader has scrolled past, which is
+      // still the section they are nearest to in the document.
+      if (!best) {
+        targets.forEach(function (el) {
+          if (el.getBoundingClientRect().top > 0) return;
+          if (!best || el.getBoundingClientRect().top > best.getBoundingClientRect().top) best = el;
+        });
+      }
+
       navLinks.forEach(function (a) { a.classList.remove('is-active'); });
       var key = best && best.getAttribute('data-spy-for');
       if (key && byId[key]) byId[key].classList.add('is-active');

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -360,9 +360,16 @@
       fs = buildFs(kb);
       syncPrompt();
       mount.classList.add('is-ready');
-      COMMANDS.neofetch();
+      // Boot into `ls` rather than the neofetch card. The card restated the
+      // role, lab, thesis, paper count, stack, funders and contact, all of
+      // which the page already says twice over, and it left most of the panel
+      // empty. Showing the filesystem instead proves in one line that this is
+      // a real shell over the CV and gives the reader somewhere to go.
+      COMMANDS.ls();
       write('&nbsp;');
-      write('Type <span class="t-accent">help</span>, or <span class="t-accent">ls</span> to look around.', 'is-dim');
+      write('Directories hold the full entries. <span class="t-accent">cat</span> one, ' +
+            '<span class="t-accent">find</span> a phrase, <span class="t-accent">open</span> a section, ' +
+            'or <span class="t-accent">ask</span> a question. <span class="t-accent">help</span> lists everything.', 'is-dim');
     })
     .catch(function () {
       write('could not load the knowledge base', 'is-err');


### PR DESCRIPTION
CRITICAL: whole sections rendered as blank white space.

The reveal hid on the `data-reveal` attribute itself and relied on one IntersectionObserver to undo it, so anything the observer missed stayed invisible permanently. At 1225x668 past the stats row that was roughly 2000px of white, including every publication card.

Hiding is now something JavaScript does, not something the markup or a stylesheet does. The CSS only hides an element carrying `.is-armed`, a class the script adds, so if the script never runs the page renders in full. Three further guards, because one observer is a single point of failure:

  - anything already at or above the fold is revealed outright and never armed, so a first paint cannot be blank
  - a throttled scroll and resize pass reveals armed elements that have come into view, independently of the observer
  - a timer reveals whatever is left after eight seconds. Late is survivable; invisible is not.

Verified by jumping (not scrolling) through every screen at 1225x668, 1440x900, 1280x800 and 390x844: zero in-viewport elements at opacity 0, against 63 before. Zero with JavaScript disabled, and zero under prefers-reduced-motion. The copy-BibTeX buttons rest at 0.55 rather than 0 for the same reason: invisible until hover is indistinguishable from a rendering fault.

Floating widgets no longer sit on the text. The launcher was a 182px pill reaching 174px into a content column that had only 32px of margin, covering thread copy by about 7,000 square pixels. It keeps the compact circular form it already used below 640px at every width, and the page reserves a flat 88px gutter, which is wider than either widget. A vw-based gutter is not enough: it dipped to 72px at 1440 and put the button back over the last few pixels of the column. Zero overlap now at all three widths.

The hero is name, role, one thesis sentence and three links. It was a three-line name, seven chips, seven links and a terminal panel that was mostly empty, so a reader met fourteen pills before one sentence of substance and the fold cut through the affiliation line. The lede owns the fold on desktop; the supporting material sits below it in two columns. The terminal moved out to its own section and boots into `ls` instead of a neofetch card that restated the role, lab, thesis, paper count, stack, funders and contact, all of which the page already said twice. It is a real shell over the CV, so it earns the space it now has.

Publications, Projects and the News archive have their own pages. The homepage keeps the argument, three papers (one per thread), three projects and five news items. The markup is shared through includes so the subset and the full list cannot drift. The page is 9,848px at 1440, down from 14,720px.

Also: the vanity stat row is gone, News is a single column rather than two with an orphan, the nav is four items, and the tagline is a sentence with a main clause rather than a dangling subordinate clause.

Scroll spy needed fixing as a consequence: with Publications now its own page, only two nav items point at homepage sections and both sit near the top, so the highlight vanished for most of the page. It now falls back to the last section scrolled past.

assistant.endpoint points at the deployed Vercel proxy, which was verified live from the github.io origin. No key is in this diff; the tree is clean of both the old and current tokens.

Verified: zero invisible elements, zero widget overlap, no contrast failures across 3 pages x 2 themes, no horizontal overflow, no page errors, and all four pages render at 1440x900, 1280x800 and 390x844.


Claude-Session: https://claude.ai/code/session_019eejz7g5zjeKJdtzbM58Lm